### PR TITLE
fix: superfluous deep env conflicts with non-dict model leaf

### DIFF
--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -42,7 +42,9 @@ def import_yaml() -> None:
     try:
         import yaml
     except ImportError as e:
-        raise ImportError('PyYAML is not installed, run `pip install pydantic-settings[yaml]`') from e
+        raise ImportError(
+            "PyYAML is not installed, run `pip install pydantic-settings[yaml]`"
+        ) from e
 
 
 def import_toml() -> None:
@@ -54,7 +56,9 @@ def import_toml() -> None:
         try:
             import tomli
         except ImportError as e:
-            raise ImportError('tomli is not installed, run `pip install pydantic-settings[toml]`') from e
+            raise ImportError(
+                "tomli is not installed, run `pip install pydantic-settings[toml]`"
+            ) from e
     else:
         if tomllib is not None:
             return
@@ -63,12 +67,12 @@ def import_toml() -> None:
 
 DotenvType = Union[Path, str, List[Union[Path, str]], Tuple[Union[Path, str], ...]]
 PathType = Union[Path, str, List[Union[Path, str]], Tuple[Union[Path, str], ...]]
-DEFAULT_PATH: PathType = Path('')
+DEFAULT_PATH: PathType = Path("")
 
 # This is used as default value for `_env_file` in the `BaseSettings` class and
 # `env_file` in `DotEnvSettingsSource` so the default can be distinguished from `None`.
 # See the docstring of `BaseSettings` for more details.
-ENV_FILE_SENTINEL: DotenvType = Path('')
+ENV_FILE_SENTINEL: DotenvType = Path("")
 
 
 class EnvNoneType(str):
@@ -89,7 +93,9 @@ class PydanticBaseSettingsSource(ABC):
         self.config = settings_cls.model_config
 
     @abstractmethod
-    def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:
+    def get_field_value(
+        self, field: FieldInfo, field_name: str
+    ) -> tuple[Any, str, bool]:
         """
         Gets the value, the key for model creation, and a flag to determine whether value is complex.
 
@@ -116,7 +122,9 @@ class PydanticBaseSettingsSource(ABC):
         """
         return _annotation_is_complex(field.annotation, field.metadata)
 
-    def prepare_field_value(self, field_name: str, field: FieldInfo, value: Any, value_is_complex: bool) -> Any:
+    def prepare_field_value(
+        self, field_name: str, field: FieldInfo, value: Any, value_is_complex: bool
+    ) -> Any:
         """
         Prepares the value of a field.
 
@@ -133,7 +141,9 @@ class PydanticBaseSettingsSource(ABC):
             return self.decode_complex_value(field_name, field, value)
         return value
 
-    def decode_complex_value(self, field_name: str, field: FieldInfo, value: Any) -> Any:
+    def decode_complex_value(
+        self, field_name: str, field: FieldInfo, value: Any
+    ) -> Any:
         """
         Decode the value for a complex field
 
@@ -161,15 +171,17 @@ class InitSettingsSource(PydanticBaseSettingsSource):
         self.init_kwargs = init_kwargs
         super().__init__(settings_cls)
 
-    def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:
+    def get_field_value(
+        self, field: FieldInfo, field_name: str
+    ) -> tuple[Any, str, bool]:
         # Nothing to do here. Only implement the return statement to make mypy happy
-        return None, '', False
+        return None, "", False
 
     def __call__(self) -> dict[str, Any]:
         return self.init_kwargs
 
     def __repr__(self) -> str:
-        return f'InitSettingsSource(init_kwargs={self.init_kwargs!r})'
+        return f"InitSettingsSource(init_kwargs={self.init_kwargs!r})"
 
 
 class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
@@ -183,20 +195,36 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
         env_parse_enums: bool | None = None,
     ) -> None:
         super().__init__(settings_cls)
-        self.case_sensitive = case_sensitive if case_sensitive is not None else self.config.get('case_sensitive', False)
-        self.env_prefix = env_prefix if env_prefix is not None else self.config.get('env_prefix', '')
+        self.case_sensitive = (
+            case_sensitive
+            if case_sensitive is not None
+            else self.config.get("case_sensitive", False)
+        )
+        self.env_prefix = (
+            env_prefix if env_prefix is not None else self.config.get("env_prefix", "")
+        )
         self.env_ignore_empty = (
-            env_ignore_empty if env_ignore_empty is not None else self.config.get('env_ignore_empty', False)
+            env_ignore_empty
+            if env_ignore_empty is not None
+            else self.config.get("env_ignore_empty", False)
         )
         self.env_parse_none_str = (
-            env_parse_none_str if env_parse_none_str is not None else self.config.get('env_parse_none_str')
+            env_parse_none_str
+            if env_parse_none_str is not None
+            else self.config.get("env_parse_none_str")
         )
-        self.env_parse_enums = env_parse_enums if env_parse_enums is not None else self.config.get('env_parse_enums')
+        self.env_parse_enums = (
+            env_parse_enums
+            if env_parse_enums is not None
+            else self.config.get("env_parse_enums")
+        )
 
     def _apply_case_sensitive(self, value: str) -> str:
         return value.lower() if not self.case_sensitive else value
 
-    def _extract_field_info(self, field: FieldInfo, field_name: str) -> list[tuple[str, str, bool]]:
+    def _extract_field_info(
+        self, field: FieldInfo, field_name: str
+    ) -> list[tuple[str, str, bool]]:
         """
         Extracts field info. This info is used to get the value of field from environment variables.
 
@@ -215,7 +243,9 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
         """
         field_info: list[tuple[str, str, bool]] = []
         if isinstance(field.validation_alias, (AliasChoices, AliasPath)):
-            v_alias: str | list[str | int] | list[list[str | int]] | None = field.validation_alias.convert_to_aliases()
+            v_alias: str | list[str | int] | list[list[str | int]] | None = (
+                field.validation_alias.convert_to_aliases()
+            )
         else:
             v_alias = field.validation_alias
 
@@ -223,22 +253,50 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
             if isinstance(v_alias, list):  # AliasChoices, AliasPath
                 for alias in v_alias:
                     if isinstance(alias, str):  # AliasPath
-                        field_info.append((alias, self._apply_case_sensitive(alias), True if len(alias) > 1 else False))
-                    elif isinstance(alias, list):  # AliasChoices
-                        first_arg = cast(str, alias[0])  # first item of an AliasChoices must be a str
                         field_info.append(
-                            (first_arg, self._apply_case_sensitive(first_arg), True if len(alias) > 1 else False)
+                            (
+                                alias,
+                                self._apply_case_sensitive(alias),
+                                True if len(alias) > 1 else False,
+                            )
+                        )
+                    elif isinstance(alias, list):  # AliasChoices
+                        first_arg = cast(
+                            str, alias[0]
+                        )  # first item of an AliasChoices must be a str
+                        field_info.append(
+                            (
+                                first_arg,
+                                self._apply_case_sensitive(first_arg),
+                                True if len(alias) > 1 else False,
+                            )
                         )
             else:  # string validation alias
                 field_info.append((v_alias, self._apply_case_sensitive(v_alias), False))
-        elif origin_is_union(get_origin(field.annotation)) and _union_is_complex(field.annotation, field.metadata):
-            field_info.append((field_name, self._apply_case_sensitive(self.env_prefix + field_name), True))
+        elif origin_is_union(get_origin(field.annotation)) and _union_is_complex(
+            field.annotation, field.metadata
+        ):
+            field_info.append(
+                (
+                    field_name,
+                    self._apply_case_sensitive(self.env_prefix + field_name),
+                    True,
+                )
+            )
         else:
-            field_info.append((field_name, self._apply_case_sensitive(self.env_prefix + field_name), False))
+            field_info.append(
+                (
+                    field_name,
+                    self._apply_case_sensitive(self.env_prefix + field_name),
+                    False,
+                )
+            )
 
         return field_info
 
-    def _replace_field_names_case_insensitively(self, field: FieldInfo, field_values: dict[str, Any]) -> dict[str, Any]:
+    def _replace_field_names_case_insensitively(
+        self, field: FieldInfo, field_values: dict[str, Any]
+    ) -> dict[str, Any]:
         """
         Replace field names in values dict by looking in models fields insensitively.
 
@@ -276,13 +334,16 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
 
             # This is here to make mypy happy
             # Item "None" of "Optional[Type[Any]]" has no attribute "model_fields"
-            if not field.annotation or not hasattr(field.annotation, 'model_fields'):
+            if not field.annotation or not hasattr(field.annotation, "model_fields"):
                 values[name] = value
                 continue
 
             # Find field in sub model by looking in fields case insensitively
             for sub_model_field_name, f in field.annotation.model_fields.items():
-                if not f.validation_alias and sub_model_field_name.lower() == name.lower():
+                if (
+                    not f.validation_alias
+                    and sub_model_field_name.lower() == name.lower()
+                ):
                     sub_model_field = f
                     break
 
@@ -290,14 +351,20 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
                 values[name] = value
                 continue
 
-            if lenient_issubclass(sub_model_field.annotation, BaseModel) and isinstance(value, dict):
-                values[sub_model_field_name] = self._replace_field_names_case_insensitively(sub_model_field, value)
+            if lenient_issubclass(sub_model_field.annotation, BaseModel) and isinstance(
+                value, dict
+            ):
+                values[sub_model_field_name] = (
+                    self._replace_field_names_case_insensitively(sub_model_field, value)
+                )
             else:
                 values[sub_model_field_name] = value
 
         return values
 
-    def _replace_env_none_type_values(self, field_value: dict[str, Any]) -> dict[str, Any]:
+    def _replace_env_none_type_values(
+        self, field_value: dict[str, Any]
+    ) -> dict[str, Any]:
         """
         Recursively parse values that are of "None" type(EnvNoneType) to `None` type(None).
         """
@@ -305,7 +372,11 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
 
         for key, value in field_value.items():
             if not isinstance(value, EnvNoneType):
-                values[key] = value if not isinstance(value, dict) else self._replace_env_none_type_values(value)
+                values[key] = (
+                    value
+                    if not isinstance(value, dict)
+                    else self._replace_env_none_type_values(value)
+                )
             else:
                 values[key] = None
 
@@ -316,14 +387,18 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
 
         for field_name, field in self.settings_cls.model_fields.items():
             try:
-                field_value, field_key, value_is_complex = self.get_field_value(field, field_name)
+                field_value, field_key, value_is_complex = self.get_field_value(
+                    field, field_name
+                )
             except Exception as e:
                 raise SettingsError(
                     f'error getting value for field "{field_name}" from source "{self.__class__.__name__}"'
                 ) from e
 
             try:
-                field_value = self.prepare_field_value(field_name, field, field_value, value_is_complex)
+                field_value = self.prepare_field_value(
+                    field_name, field, field_value, value_is_complex
+                )
             except ValueError as e:
                 raise SettingsError(
                     f'error parsing value for field "{field_name}" from source "{self.__class__.__name__}"'
@@ -340,7 +415,9 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
                     and lenient_issubclass(field.annotation, BaseModel)
                     and isinstance(field_value, dict)
                 ):
-                    data[field_key] = self._replace_field_names_case_insensitively(field, field_value)
+                    data[field_key] = self._replace_field_names_case_insensitively(
+                        field, field_value
+                    )
                 else:
                     data[field_key] = field_value
 
@@ -363,9 +440,16 @@ class SecretsSettingsSource(PydanticBaseEnvSettingsSource):
         env_parse_enums: bool | None = None,
     ) -> None:
         super().__init__(
-            settings_cls, case_sensitive, env_prefix, env_ignore_empty, env_parse_none_str, env_parse_enums
+            settings_cls,
+            case_sensitive,
+            env_prefix,
+            env_ignore_empty,
+            env_parse_none_str,
+            env_parse_enums,
         )
-        self.secrets_dir = secrets_dir if secrets_dir is not None else self.config.get('secrets_dir')
+        self.secrets_dir = (
+            secrets_dir if secrets_dir is not None else self.config.get("secrets_dir")
+        )
 
     def __call__(self) -> dict[str, Any]:
         """
@@ -383,12 +467,16 @@ class SecretsSettingsSource(PydanticBaseEnvSettingsSource):
             return secrets
 
         if not self.secrets_path.is_dir():
-            raise SettingsError(f'secrets_dir must reference a directory, not a {path_type_label(self.secrets_path)}')
+            raise SettingsError(
+                f"secrets_dir must reference a directory, not a {path_type_label(self.secrets_path)}"
+            )
 
         return super().__call__()
 
     @classmethod
-    def find_case_path(cls, dir_path: Path, file_name: str, case_sensitive: bool) -> Path | None:
+    def find_case_path(
+        cls, dir_path: Path, file_name: str, case_sensitive: bool
+    ) -> Path | None:
         """
         Find a file within path's directory matching filename, optionally ignoring case.
 
@@ -407,7 +495,9 @@ class SecretsSettingsSource(PydanticBaseEnvSettingsSource):
                 return f
         return None
 
-    def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:
+    def get_field_value(
+        self, field: FieldInfo, field_name: str
+    ) -> tuple[Any, str, bool]:
         """
         Gets the value for field from secret file and a flag to determine whether value is complex.
 
@@ -420,7 +510,9 @@ class SecretsSettingsSource(PydanticBaseEnvSettingsSource):
                 a flag to determine whether value is complex.
         """
 
-        for field_key, env_name, value_is_complex in self._extract_field_info(field, field_name):
+        for field_key, env_name, value_is_complex in self._extract_field_info(
+            field, field_name
+        ):
             path = self.find_case_path(self.secrets_path, env_name, self.case_sensitive)
             if not path:
                 # path does not exist, we currently don't return a warning for this
@@ -437,7 +529,7 @@ class SecretsSettingsSource(PydanticBaseEnvSettingsSource):
         return None, field_key, value_is_complex
 
     def __repr__(self) -> str:
-        return f'SecretsSettingsSource(secrets_dir={self.secrets_dir!r})'
+        return f"SecretsSettingsSource(secrets_dir={self.secrets_dir!r})"
 
 
 class EnvSettingsSource(PydanticBaseEnvSettingsSource):
@@ -456,19 +548,33 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
         env_parse_enums: bool | None = None,
     ) -> None:
         super().__init__(
-            settings_cls, case_sensitive, env_prefix, env_ignore_empty, env_parse_none_str, env_parse_enums
+            settings_cls,
+            case_sensitive,
+            env_prefix,
+            env_ignore_empty,
+            env_parse_none_str,
+            env_parse_enums,
         )
         self.env_nested_delimiter = (
-            env_nested_delimiter if env_nested_delimiter is not None else self.config.get('env_nested_delimiter')
+            env_nested_delimiter
+            if env_nested_delimiter is not None
+            else self.config.get("env_nested_delimiter")
         )
         self.env_prefix_len = len(self.env_prefix)
 
         self.env_vars = self._load_env_vars()
 
     def _load_env_vars(self) -> Mapping[str, str | None]:
-        return parse_env_vars(os.environ, self.case_sensitive, self.env_ignore_empty, self.env_parse_none_str)
+        return parse_env_vars(
+            os.environ,
+            self.case_sensitive,
+            self.env_ignore_empty,
+            self.env_parse_none_str,
+        )
 
-    def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:
+    def get_field_value(
+        self, field: FieldInfo, field_name: str
+    ) -> tuple[Any, str, bool]:
         """
         Gets the value for field from environment variables and a flag to determine whether value is complex.
 
@@ -482,14 +588,18 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
         """
 
         env_val: str | None = None
-        for field_key, env_name, value_is_complex in self._extract_field_info(field, field_name):
+        for field_key, env_name, value_is_complex in self._extract_field_info(
+            field, field_name
+        ):
             env_val = self.env_vars.get(env_name)
             if env_val is not None:
                 break
 
         return env_val, field_key, value_is_complex
 
-    def prepare_field_value(self, field_name: str, field: FieldInfo, value: Any, value_is_complex: bool) -> Any:
+    def prepare_field_value(
+        self, field_name: str, field: FieldInfo, value: Any, value_is_complex: bool
+    ) -> Any:
         """
         Prepare value for the field.
 
@@ -526,7 +636,9 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
                         raise e
 
                 if isinstance(value, dict):
-                    return deep_update(value, self.explode_env_vars(field_name, field, self.env_vars))
+                    return deep_update(
+                        value, self.explode_env_vars(field_name, field, self.env_vars)
+                    )
                 else:
                     return value
         elif value is not None:
@@ -539,7 +651,9 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
         """
         if self.field_is_complex(field):
             allow_parse_failure = False
-        elif origin_is_union(get_origin(field.annotation)) and _union_is_complex(field.annotation, field.metadata):
+        elif origin_is_union(get_origin(field.annotation)) and _union_is_complex(
+            field.annotation, field.metadata
+        ):
             allow_parse_failure = True
         else:
             return False, False
@@ -580,7 +694,9 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
             return None
 
         annotation = field.annotation if isinstance(field, FieldInfo) else field
-        if origin_is_union(get_origin(annotation)) or isinstance(annotation, WithArgsTypes):
+        if origin_is_union(get_origin(annotation)) or isinstance(
+            annotation, WithArgsTypes
+        ):
             for type_ in get_args(annotation):
                 type_has_key = EnvSettingsSource.next_field(type_, key)
                 if type_has_key:
@@ -590,7 +706,9 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
 
         return None
 
-    def explode_env_vars(self, field_name: str, field: FieldInfo, env_vars: Mapping[str, str | None]) -> dict[str, Any]:
+    def explode_env_vars(
+        self, field_name: str, field: FieldInfo, env_vars: Mapping[str, str | None]
+    ) -> dict[str, Any]:
         """
         Process env_vars and extract the values of keys containing env_nested_delimiter into nested dictionaries.
 
@@ -607,7 +725,8 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
         is_dict = lenient_issubclass(get_origin(field.annotation), dict)
 
         prefixes = [
-            f'{env_name}{self.env_nested_delimiter}' for _, env_name, _ in self._extract_field_info(field, field_name)
+            f"{env_name}{self.env_nested_delimiter}"
+            for _, env_name, _ in self._extract_field_info(field, field_name)
         ]
         result: dict[str, Any] = {}
         for env_name, env_val in env_vars.items():
@@ -615,7 +734,9 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
                 continue
             # we remove the prefix before splitting in case the prefix has characters in common with the delimiter
             env_name_without_prefix = env_name[self.env_prefix_len :]
-            _, *keys, last_key = env_name_without_prefix.split(self.env_nested_delimiter)
+            _, *keys, last_key = env_name_without_prefix.split(
+                self.env_nested_delimiter
+            )
             env_var = result
             target_field: FieldInfo | None = field
             for key in keys:
@@ -628,7 +749,9 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
             # check if env_val maps to a complex field and if so, parse the env_val
             if (target_field or is_dict) and env_val:
                 if target_field:
-                    is_complex, allow_json_failure = self._field_is_complex(target_field)
+                    is_complex, allow_json_failure = self._field_is_complex(
+                        target_field
+                    )
                 else:
                     # nested field type is dict
                     is_complex, allow_json_failure = True, False
@@ -638,14 +761,16 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
                     except ValueError as e:
                         if not allow_json_failure:
                             raise e
-            env_var[last_key] = env_val
+
+            if isinstance(env_var, dict):
+                env_var[last_key] = env_val
 
         return result
 
     def __repr__(self) -> str:
         return (
-            f'EnvSettingsSource(env_nested_delimiter={self.env_nested_delimiter!r}, '
-            f'env_prefix_len={self.env_prefix_len!r})'
+            f"EnvSettingsSource(env_nested_delimiter={self.env_nested_delimiter!r}, "
+            f"env_prefix_len={self.env_prefix_len!r})"
         )
 
 
@@ -666,9 +791,15 @@ class DotEnvSettingsSource(EnvSettingsSource):
         env_parse_none_str: str | None = None,
         env_parse_enums: bool | None = None,
     ) -> None:
-        self.env_file = env_file if env_file != ENV_FILE_SENTINEL else settings_cls.model_config.get('env_file')
+        self.env_file = (
+            env_file
+            if env_file != ENV_FILE_SENTINEL
+            else settings_cls.model_config.get("env_file")
+        )
         self.env_file_encoding = (
-            env_file_encoding if env_file_encoding is not None else settings_cls.model_config.get('env_file_encoding')
+            env_file_encoding
+            if env_file_encoding is not None
+            else settings_cls.model_config.get("env_file_encoding")
         )
         super().__init__(
             settings_cls,
@@ -709,7 +840,7 @@ class DotEnvSettingsSource(EnvSettingsSource):
 
     def __call__(self) -> dict[str, Any]:
         data: dict[str, Any] = super().__call__()
-        is_extra_allowed = self.config.get('extra') != 'forbid'
+        is_extra_allowed = self.config.get("extra") != "forbid"
 
         # As `extra` config is allowed in dotenv settings source, We have to
         # update data with extra env variables from dotenv file.
@@ -733,8 +864,8 @@ class DotEnvSettingsSource(EnvSettingsSource):
 
     def __repr__(self) -> str:
         return (
-            f'DotEnvSettingsSource(env_file={self.env_file!r}, env_file_encoding={self.env_file_encoding!r}, '
-            f'env_nested_delimiter={self.env_nested_delimiter!r}, env_prefix_len={self.env_prefix_len!r})'
+            f"DotEnvSettingsSource(env_file={self.env_file!r}, env_file_encoding={self.env_file_encoding!r}, "
+            f"env_nested_delimiter={self.env_nested_delimiter!r}, env_prefix_len={self.env_prefix_len!r})"
         )
 
 
@@ -767,11 +898,15 @@ class JsonConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
         json_file: PathType | None = DEFAULT_PATH,
         json_file_encoding: str | None = None,
     ):
-        self.json_file_path = json_file if json_file != DEFAULT_PATH else settings_cls.model_config.get('json_file')
+        self.json_file_path = (
+            json_file
+            if json_file != DEFAULT_PATH
+            else settings_cls.model_config.get("json_file")
+        )
         self.json_file_encoding = (
             json_file_encoding
             if json_file_encoding is not None
-            else settings_cls.model_config.get('json_file_encoding')
+            else settings_cls.model_config.get("json_file_encoding")
         )
         self.json_data = self._read_files(self.json_file_path)
         super().__init__(settings_cls, self.json_data)
@@ -791,13 +926,17 @@ class TomlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
         settings_cls: type[BaseSettings],
         toml_file: PathType | None = DEFAULT_PATH,
     ):
-        self.toml_file_path = toml_file if toml_file != DEFAULT_PATH else settings_cls.model_config.get('toml_file')
+        self.toml_file_path = (
+            toml_file
+            if toml_file != DEFAULT_PATH
+            else settings_cls.model_config.get("toml_file")
+        )
         self.toml_data = self._read_files(self.toml_file_path)
         super().__init__(settings_cls, self.toml_data)
 
     def _read_file(self, file_path: Path) -> dict[str, Any]:
         import_toml()
-        with open(file_path, mode='rb') as toml_file:
+        with open(file_path, mode="rb") as toml_file:
             if sys.version_info < (3, 11):
                 return tomli.load(toml_file)
             return tomllib.load(toml_file)
@@ -814,10 +953,10 @@ class PyprojectTomlConfigSettingsSource(TomlConfigSettingsSource):
         toml_file: Path | None = None,
     ) -> None:
         self.toml_file_path = self._pick_pyproject_toml_file(
-            toml_file, settings_cls.model_config.get('pyproject_toml_depth', 0)
+            toml_file, settings_cls.model_config.get("pyproject_toml_depth", 0)
         )
         self.toml_table_header: tuple[str, ...] = settings_cls.model_config.get(
-            'pyproject_toml_table_header', ('tool', 'pydantic-settings')
+            "pyproject_toml_table_header", ("tool", "pydantic-settings")
         )
         self.toml_data = self._read_files(self.toml_file_path)
         for key in self.toml_table_header:
@@ -835,16 +974,16 @@ class PyprojectTomlConfigSettingsSource(TomlConfigSettingsSource):
         """
         if provided:
             return provided.resolve()
-        rv = Path.cwd() / 'pyproject.toml'
+        rv = Path.cwd() / "pyproject.toml"
         count = 0
         if not rv.is_file():
-            child = rv.parent.parent / 'pyproject.toml'
+            child = rv.parent.parent / "pyproject.toml"
             while count < depth:
                 if child.is_file():
                     return child
                 if str(child.parent) == rv.root:
                     break  # end discovery after checking system root once
-                child = child.parent.parent / 'pyproject.toml'
+                child = child.parent.parent / "pyproject.toml"
                 count += 1
         return rv
 
@@ -860,11 +999,15 @@ class YamlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
         yaml_file: PathType | None = DEFAULT_PATH,
         yaml_file_encoding: str | None = None,
     ):
-        self.yaml_file_path = yaml_file if yaml_file != DEFAULT_PATH else settings_cls.model_config.get('yaml_file')
+        self.yaml_file_path = (
+            yaml_file
+            if yaml_file != DEFAULT_PATH
+            else settings_cls.model_config.get("yaml_file")
+        )
         self.yaml_file_encoding = (
             yaml_file_encoding
             if yaml_file_encoding is not None
-            else settings_cls.model_config.get('yaml_file_encoding')
+            else settings_cls.model_config.get("yaml_file_encoding")
         )
         self.yaml_data = self._read_files(self.yaml_file_path)
         super().__init__(settings_cls, self.yaml_data)
@@ -879,8 +1022,14 @@ def _get_env_var_key(key: str, case_sensitive: bool = False) -> str:
     return key if case_sensitive else key.lower()
 
 
-def _parse_env_none_str(value: str | None, parse_none_str: str | None = None) -> str | None | EnvNoneType:
-    return value if not (value == parse_none_str and parse_none_str is not None) else EnvNoneType(value)
+def _parse_env_none_str(
+    value: str | None, parse_none_str: str | None = None
+) -> str | None | EnvNoneType:
+    return (
+        value
+        if not (value == parse_none_str and parse_none_str is not None)
+        else EnvNoneType(value)
+    )
 
 
 def parse_env_vars(
@@ -892,7 +1041,7 @@ def parse_env_vars(
     return {
         _get_env_var_key(k, case_sensitive): _parse_env_none_str(v, parse_none_str)
         for k, v in env_vars.items()
-        if not (ignore_empty and v == '')
+        if not (ignore_empty and v == "")
     }
 
 
@@ -904,7 +1053,9 @@ def read_env_file(
     ignore_empty: bool = False,
     parse_none_str: str | None = None,
 ) -> Mapping[str, str | None]:
-    file_vars: dict[str, str | None] = dotenv_values(file_path, encoding=encoding or 'utf8')
+    file_vars: dict[str, str | None] = dotenv_values(
+        file_path, encoding=encoding or "utf8"
+    )
     return parse_env_vars(file_vars, case_sensitive, ignore_empty, parse_none_str)
 
 
@@ -915,8 +1066,8 @@ def _annotation_is_complex(annotation: type[Any] | None, metadata: list[Any]) ->
     return (
         _annotation_is_complex_inner(annotation)
         or _annotation_is_complex_inner(origin)
-        or hasattr(origin, '__pydantic_core_schema__')
-        or hasattr(origin, '__get_pydantic_core_schema__')
+        or hasattr(origin, "__pydantic_core_schema__")
+        or hasattr(origin, "__get_pydantic_core_schema__")
     )
 
 
@@ -924,9 +1075,9 @@ def _annotation_is_complex_inner(annotation: type[Any] | None) -> bool:
     if lenient_issubclass(annotation, (str, bytes)):
         return False
 
-    return lenient_issubclass(annotation, (BaseModel, Mapping, Sequence, tuple, set, frozenset, deque)) or is_dataclass(
-        annotation
-    )
+    return lenient_issubclass(
+        annotation, (BaseModel, Mapping, Sequence, tuple, set, frozenset, deque)
+    ) or is_dataclass(annotation)
 
 
 def _union_is_complex(annotation: type[Any] | None, metadata: list[Any]) -> bool:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3,10 +3,23 @@ import json
 import os
 import sys
 import uuid
+from collections import OrderedDict
 from datetime import datetime, timezone
 from enum import IntEnum
 from pathlib import Path
-from typing import Any, Callable, Dict, Generic, List, Optional, Set, Tuple, Type, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 import pytest
 from annotated_types import MinLen
@@ -21,9 +34,7 @@ from pydantic import (
     SecretStr,
     ValidationError,
 )
-from pydantic import (
-    dataclasses as pydantic_dataclasses,
-)
+from pydantic import dataclasses as pydantic_dataclasses
 from pydantic.fields import FieldInfo
 from pytest_mock import MockerFixture
 from typing_extensions import Annotated
@@ -62,85 +73,85 @@ class SimpleSettings(BaseSettings):
 
 
 class SettingWithIgnoreEmpty(BaseSettings):
-    apple: str = 'default'
+    apple: str = "default"
 
     model_config = SettingsConfigDict(env_ignore_empty=True)
 
 
 def test_sub_env(env):
-    env.set('apple', 'hello')
+    env.set("apple", "hello")
     s = SimpleSettings()
-    assert s.apple == 'hello'
+    assert s.apple == "hello"
 
 
 def test_sub_env_override(env):
-    env.set('apple', 'hello')
-    s = SimpleSettings(apple='goodbye')
-    assert s.apple == 'goodbye'
+    env.set("apple", "hello")
+    s = SimpleSettings(apple="goodbye")
+    assert s.apple == "goodbye"
 
 
 def test_sub_env_missing():
     with pytest.raises(ValidationError) as exc_info:
         SimpleSettings()
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'missing', 'loc': ('apple',), 'msg': 'Field required', 'input': {}}
+        {"type": "missing", "loc": ("apple",), "msg": "Field required", "input": {}}
     ]
 
 
 def test_other_setting():
     with pytest.raises(ValidationError):
-        SimpleSettings(apple='a', foobar=42)
+        SimpleSettings(apple="a", foobar=42)
 
 
 def test_ignore_empty_when_empty_uses_default(env):
-    env.set('apple', '')
+    env.set("apple", "")
     s = SettingWithIgnoreEmpty()
-    assert s.apple == 'default'
+    assert s.apple == "default"
 
 
 def test_ignore_empty_when_not_empty_uses_value(env):
-    env.set('apple', 'a')
+    env.set("apple", "a")
     s = SettingWithIgnoreEmpty()
-    assert s.apple == 'a'
+    assert s.apple == "a"
 
 
 def test_ignore_empty_with_dotenv_when_empty_uses_default(tmp_path):
-    p = tmp_path / '.env'
-    p.write_text('a=')
+    p = tmp_path / ".env"
+    p.write_text("a=")
 
     class Settings(BaseSettings):
-        a: str = 'default'
+        a: str = "default"
 
         model_config = SettingsConfigDict(env_file=p, env_ignore_empty=True)
 
     s = Settings()
-    assert s.a == 'default'
+    assert s.a == "default"
 
 
 def test_ignore_empty_with_dotenv_when_not_empty_uses_value(tmp_path):
-    p = tmp_path / '.env'
-    p.write_text('a=b')
+    p = tmp_path / ".env"
+    p.write_text("a=b")
 
     class Settings(BaseSettings):
-        a: str = 'default'
+        a: str = "default"
 
         model_config = SettingsConfigDict(env_file=p, env_ignore_empty=True)
 
     s = Settings()
-    assert s.a == 'b'
+    assert s.a == "b"
 
 
 def test_with_prefix(env):
     class Settings(BaseSettings):
         apple: str
 
-        model_config = SettingsConfigDict(env_prefix='foobar_')
+        model_config = SettingsConfigDict(env_prefix="foobar_")
 
     with pytest.raises(ValidationError):
         Settings()
-    env.set('foobar_apple', 'has_prefix')
+    env.set("foobar_apple", "has_prefix")
     s = Settings()
-    assert s.apple == 'has_prefix'
+    assert s.apple == "has_prefix"
 
 
 def test_nested_env_with_basemodel(env):
@@ -153,10 +164,10 @@ def test_nested_env_with_basemodel(env):
 
     with pytest.raises(ValidationError):
         Settings()
-    env.set('top', '{"banana": "secret_value"}')
-    s = Settings(top={'apple': 'value'})
-    assert s.top.apple == 'value'
-    assert s.top.banana == 'secret_value'
+    env.set("top", '{"banana": "secret_value"}')
+    s = Settings(top={"apple": "value"})
+    assert s.top.apple == "value"
+    assert s.top.banana == "secret_value"
 
 
 def test_merge_dict(env):
@@ -165,9 +176,9 @@ def test_merge_dict(env):
 
     with pytest.raises(ValidationError):
         Settings()
-    env.set('top', '{"banana": "secret_value"}')
-    s = Settings(top={'apple': 'value'})
-    assert s.top == {'apple': 'value', 'banana': 'secret_value'}
+    env.set("top", '{"banana": "secret_value"}')
+    s = Settings(top={"apple": "value"})
+    assert s.top == {"apple": "value", "banana": "secret_value"}
 
 
 def test_nested_env_delimiter(env):
@@ -190,25 +201,25 @@ def test_nested_env_delimiter(env):
         v0_union: Union[SubValue, int]
         top: TopValue
 
-        model_config = SettingsConfigDict(env_nested_delimiter='__')
+        model_config = SettingsConfigDict(env_nested_delimiter="__")
 
-    env.set('top', '{"v1": "json-1", "v2": "json-2", "sub": {"v5": "xx"}}')
-    env.set('top__sub__v5', '5')
-    env.set('v0', '0')
-    env.set('top__v2', '2')
-    env.set('top__v3', '3')
-    env.set('v0_union', '0')
-    env.set('top__sub__sub_sub__v6', '6')
-    env.set('top__sub__v4', '4')
+    env.set("top", '{"v1": "json-1", "v2": "json-2", "sub": {"v5": "xx"}}')
+    env.set("top__sub__v5", "5")
+    env.set("v0", "0")
+    env.set("top__v2", "2")
+    env.set("top__v3", "3")
+    env.set("v0_union", "0")
+    env.set("top__sub__sub_sub__v6", "6")
+    env.set("top__sub__v4", "4")
     cfg = Cfg()
     assert cfg.model_dump() == {
-        'v0': '0',
-        'v0_union': 0,
-        'top': {
-            'v1': 'json-1',
-            'v2': '2',
-            'v3': '3',
-            'sub': {'v4': '4', 'v5': 5, 'sub_sub': {'v6': '6'}},
+        "v0": "0",
+        "v0_union": 0,
+        "top": {
+            "v1": "json-1",
+            "v2": "2",
+            "v3": "3",
+            "sub": {"v4": "4", "v5": 5, "sub_sub": {"v6": "6"}},
         },
     }
 
@@ -217,14 +228,14 @@ def test_nested_env_optional_json(env):
     class Child(BaseModel):
         num_list: Optional[List[int]] = None
 
-    class Cfg(BaseSettings, env_nested_delimiter='__'):
+    class Cfg(BaseSettings, env_nested_delimiter="__"):
         child: Optional[Child] = None
 
-    env.set('CHILD__NUM_LIST', '[1,2,3]')
+    env.set("CHILD__NUM_LIST", "[1,2,3]")
     cfg = Cfg()
     assert cfg.model_dump() == {
-        'child': {
-            'num_list': [1, 2, 3],
+        "child": {
+            "num_list": [1, 2, 3],
         },
     }
 
@@ -236,32 +247,36 @@ def test_nested_env_delimiter_with_prefix(env):
     class Settings(BaseSettings):
         subsettings: Subsettings
 
-        model_config = SettingsConfigDict(env_nested_delimiter='_', env_prefix='myprefix_')
+        model_config = SettingsConfigDict(
+            env_nested_delimiter="_", env_prefix="myprefix_"
+        )
 
-    env.set('myprefix_subsettings_banana', 'banana')
+    env.set("myprefix_subsettings_banana", "banana")
     s = Settings()
-    assert s.subsettings.banana == 'banana'
+    assert s.subsettings.banana == "banana"
 
     class Settings(BaseSettings):
         subsettings: Subsettings
 
-        model_config = SettingsConfigDict(env_nested_delimiter='_', env_prefix='myprefix__')
+        model_config = SettingsConfigDict(
+            env_nested_delimiter="_", env_prefix="myprefix__"
+        )
 
-    env.set('myprefix__subsettings_banana', 'banana')
+    env.set("myprefix__subsettings_banana", "banana")
     s = Settings()
-    assert s.subsettings.banana == 'banana'
+    assert s.subsettings.banana == "banana"
 
 
 def test_nested_env_delimiter_complex_required(env):
     class Cfg(BaseSettings):
-        v: str = 'default'
+        v: str = "default"
 
-        model_config = SettingsConfigDict(env_nested_delimiter='__')
+        model_config = SettingsConfigDict(env_nested_delimiter="__")
 
-    env.set('v__x', 'x')
-    env.set('v__y', 'y')
+    env.set("v__x", "x")
+    env.set("v__y", "y")
     cfg = Cfg()
-    assert cfg.model_dump() == {'v': 'default'}
+    assert cfg.model_dump() == {"v": "default"}
 
 
 def test_nested_env_delimiter_aliases(env):
@@ -270,13 +285,13 @@ def test_nested_env_delimiter_aliases(env):
         v2: str
 
     class Cfg(BaseSettings):
-        sub_model: SubModel = Field(validation_alias=AliasChoices('foo', 'bar'))
+        sub_model: SubModel = Field(validation_alias=AliasChoices("foo", "bar"))
 
-        model_config = SettingsConfigDict(env_nested_delimiter='__')
+        model_config = SettingsConfigDict(env_nested_delimiter="__")
 
-    env.set('foo__v1', '-1-')
-    env.set('bar__v2', '-2-')
-    assert Cfg().model_dump() == {'sub_model': {'v1': '-1-', 'v2': '-2-'}}
+    env.set("foo__v1", "-1-")
+    env.set("bar__v2", "-2-")
+    assert Cfg().model_dump() == {"sub_model": {"v1": "-1-", "v2": "-2-"}}
 
 
 class DateModel(BaseModel):
@@ -291,9 +306,9 @@ class ComplexSettings(BaseSettings):
 
 
 def test_list(env):
-    env.set('apples', '["russet", "granny smith"]')
+    env.set("apples", '["russet", "granny smith"]')
     s = ComplexSettings()
-    assert s.apples == ['russet', 'granny smith']
+    assert s.apples == ["russet", "granny smith"]
     assert s.date.pips is False
 
 
@@ -301,37 +316,40 @@ def test_annotated_list(env):
     class AnnotatedComplexSettings(BaseSettings):
         apples: Annotated[List[str], MinLen(2)] = []
 
-    env.set('apples', '["russet", "granny smith"]')
+    env.set("apples", '["russet", "granny smith"]')
     s = AnnotatedComplexSettings()
-    assert s.apples == ['russet', 'granny smith']
+    assert s.apples == ["russet", "granny smith"]
 
-    env.set('apples', '["russet"]')
+    env.set("apples", '["russet"]')
     with pytest.raises(ValidationError) as exc_info:
         AnnotatedComplexSettings()
     assert exc_info.value.errors(include_url=False) == [
         {
-            'ctx': {'actual_length': 1, 'field_type': 'List', 'min_length': 2},
-            'input': ['russet'],
-            'loc': ('apples',),
-            'msg': 'List should have at least 2 items after validation, not 1',
-            'type': 'too_short',
+            "ctx": {"actual_length": 1, "field_type": "List", "min_length": 2},
+            "input": ["russet"],
+            "loc": ("apples",),
+            "msg": "List should have at least 2 items after validation, not 1",
+            "type": "too_short",
         }
     ]
 
 
 def test_set_dict_model(env):
-    env.set('bananas', '[1, 2, 3, 3]')
-    env.set('CARROTS', '{"a": null, "b": 4}')
-    env.set('daTE', '{"pips": true}')
+    env.set("bananas", "[1, 2, 3, 3]")
+    env.set("CARROTS", '{"a": null, "b": 4}')
+    env.set("daTE", '{"pips": true}')
     s = ComplexSettings()
     assert s.bananas == {1, 2, 3}
-    assert s.carrots == {'a': None, 'b': 4}
+    assert s.carrots == {"a": None, "b": 4}
     assert s.date.pips is True
 
 
 def test_invalid_json(env):
-    env.set('apples', '["russet", "granny smith",]')
-    with pytest.raises(SettingsError, match='error parsing value for field "apples" from source "EnvSettingsSource"'):
+    env.set("apples", '["russet", "granny smith",]')
+    with pytest.raises(
+        SettingsError,
+        match='error parsing value for field "apples" from source "EnvSettingsSource"',
+    ):
         ComplexSettings()
 
 
@@ -341,7 +359,7 @@ def test_required_sub_model(env):
 
     with pytest.raises(ValidationError):
         Settings()
-    env.set('FOOBAR', '{"pips": "TRUE"}')
+    env.set("FOOBAR", '{"pips": "TRUE"}')
     s = Settings()
     assert s.foobar.pips is True
 
@@ -350,14 +368,16 @@ def test_non_class(env):
     class Settings(BaseSettings):
         foobar: Optional[str]
 
-    env.set('FOOBAR', 'xxx')
+    env.set("FOOBAR", "xxx")
     s = Settings()
-    assert s.foobar == 'xxx'
+    assert s.foobar == "xxx"
 
 
-@pytest.mark.parametrize('dataclass_decorator', (pydantic_dataclasses.dataclass, dataclasses.dataclass))
+@pytest.mark.parametrize(
+    "dataclass_decorator", (pydantic_dataclasses.dataclass, dataclasses.dataclass)
+)
 def test_generic_dataclass(env, dataclass_decorator):
-    T = TypeVar('T')
+    T = TypeVar("T")
 
     @dataclass_decorator
     class GenericDataclass(Generic[T]):
@@ -366,25 +386,25 @@ def test_generic_dataclass(env, dataclass_decorator):
     class ComplexSettings(BaseSettings):
         field: GenericDataclass[int]
 
-    env.set('field', '{"x": 1}')
+    env.set("field", '{"x": 1}')
     s = ComplexSettings()
     assert s.field.x == 1
 
-    env.set('field', '{"x": "a"}')
+    env.set("field", '{"x": "a"}')
     with pytest.raises(ValidationError) as exc_info:
         ComplexSettings()
     assert exc_info.value.errors(include_url=False) == [
         {
-            'input': 'a',
-            'loc': ('field', 'x'),
-            'msg': 'Input should be a valid integer, unable to parse string as an integer',
-            'type': 'int_parsing',
+            "input": "a",
+            "loc": ("field", "x"),
+            "msg": "Input should be a valid integer, unable to parse string as an integer",
+            "type": "int_parsing",
         }
     ]
 
 
 def test_generic_basemodel(env):
-    T = TypeVar('T')
+    T = TypeVar("T")
 
     class GenericModel(BaseModel, Generic[T]):
         x: T
@@ -392,25 +412,25 @@ def test_generic_basemodel(env):
     class ComplexSettings(BaseSettings):
         field: GenericModel[int]
 
-    env.set('field', '{"x": 1}')
+    env.set("field", '{"x": 1}')
     s = ComplexSettings()
     assert s.field.x == 1
 
-    env.set('field', '{"x": "a"}')
+    env.set("field", '{"x": "a"}')
     with pytest.raises(ValidationError) as exc_info:
         ComplexSettings()
     assert exc_info.value.errors(include_url=False) == [
         {
-            'input': 'a',
-            'loc': ('field', 'x'),
-            'msg': 'Input should be a valid integer, unable to parse string as an integer',
-            'type': 'int_parsing',
+            "input": "a",
+            "loc": ("field", "x"),
+            "msg": "Input should be a valid integer, unable to parse string as an integer",
+            "type": "int_parsing",
         }
     ]
 
 
 def test_annotated(env):
-    T = TypeVar('T')
+    T = TypeVar("T")
 
     class GenericModel(BaseModel, Generic[T]):
         x: T
@@ -418,126 +438,127 @@ def test_annotated(env):
     class ComplexSettings(BaseSettings):
         field: GenericModel[int]
 
-    env.set('field', '{"x": 1}')
+    env.set("field", '{"x": 1}')
     s = ComplexSettings()
     assert s.field.x == 1
 
-    env.set('field', '{"x": "a"}')
+    env.set("field", '{"x": "a"}')
     with pytest.raises(ValidationError) as exc_info:
         ComplexSettings()
     assert exc_info.value.errors(include_url=False) == [
         {
-            'input': 'a',
-            'loc': ('field', 'x'),
-            'msg': 'Input should be a valid integer, unable to parse string as an integer',
-            'type': 'int_parsing',
+            "input": "a",
+            "loc": ("field", "x"),
+            "msg": "Input should be a valid integer, unable to parse string as an integer",
+            "type": "int_parsing",
         }
     ]
 
 
 def test_env_str(env):
     class Settings(BaseSettings):
-        apple: str = Field(None, validation_alias='BOOM')
+        apple: str = Field(None, validation_alias="BOOM")
 
-    env.set('BOOM', 'hello')
-    assert Settings().apple == 'hello'
+    env.set("BOOM", "hello")
+    assert Settings().apple == "hello"
 
 
 def test_env_list(env):
     class Settings(BaseSettings):
-        foobar: str = Field(validation_alias=AliasChoices('different1', 'different2'))
+        foobar: str = Field(validation_alias=AliasChoices("different1", "different2"))
 
-    env.set('different1', 'value 1')
-    env.set('different2', 'value 2')
+    env.set("different1", "value 1")
+    env.set("different2", "value 2")
     s = Settings()
-    assert s.foobar == 'value 1'
+    assert s.foobar == "value 1"
 
 
 def test_env_list_field(env):
     class Settings(BaseSettings):
-        foobar: str = Field(validation_alias='foobar_env_name')
+        foobar: str = Field(validation_alias="foobar_env_name")
 
-    env.set('FOOBAR_ENV_NAME', 'env value')
+    env.set("FOOBAR_ENV_NAME", "env value")
     s = Settings()
-    assert s.foobar == 'env value'
+    assert s.foobar == "env value"
 
 
 def test_env_list_last(env):
     class Settings(BaseSettings):
-        foobar: str = Field(validation_alias=AliasChoices('different2'))
+        foobar: str = Field(validation_alias=AliasChoices("different2"))
 
-    env.set('different1', 'value 1')
-    env.set('different2', 'value 2')
+    env.set("different1", "value 1")
+    env.set("different2", "value 2")
     s = Settings()
-    assert s.foobar == 'value 2'
+    assert s.foobar == "value 2"
 
 
 def test_env_inheritance_field(env):
     class SettingsParent(BaseSettings):
-        foobar: str = Field('parent default', validation_alias='foobar_env')
+        foobar: str = Field("parent default", validation_alias="foobar_env")
 
     class SettingsChild(SettingsParent):
-        foobar: str = 'child default'
+        foobar: str = "child default"
 
-    assert SettingsParent().foobar == 'parent default'
+    assert SettingsParent().foobar == "parent default"
 
-    assert SettingsChild().foobar == 'child default'
-    assert SettingsChild(foobar='abc').foobar == 'abc'
-    env.set('foobar_env', 'env value')
-    assert SettingsParent().foobar == 'env value'
-    assert SettingsChild().foobar == 'child default'
-    assert SettingsChild(foobar='abc').foobar == 'abc'
+    assert SettingsChild().foobar == "child default"
+    assert SettingsChild(foobar="abc").foobar == "abc"
+    env.set("foobar_env", "env value")
+    assert SettingsParent().foobar == "env value"
+    assert SettingsChild().foobar == "child default"
+    assert SettingsChild(foobar="abc").foobar == "abc"
 
 
 def test_env_inheritance_config(env):
-    env.set('foobar', 'foobar')
-    env.set('prefix_foobar', 'prefix_foobar')
+    env.set("foobar", "foobar")
+    env.set("prefix_foobar", "prefix_foobar")
 
-    env.set('foobar_parent_from_field', 'foobar_parent_from_field')
-    env.set('prefix_foobar_parent_from_field', 'prefix_foobar_parent_from_field')
+    env.set("foobar_parent_from_field", "foobar_parent_from_field")
+    env.set("prefix_foobar_parent_from_field", "prefix_foobar_parent_from_field")
 
-    env.set('foobar_parent_from_config', 'foobar_parent_from_config')
-    env.set('foobar_child_from_config', 'foobar_child_from_config')
+    env.set("foobar_parent_from_config", "foobar_parent_from_config")
+    env.set("foobar_child_from_config", "foobar_child_from_config")
 
-    env.set('foobar_child_from_field', 'foobar_child_from_field')
+    env.set("foobar_child_from_field", "foobar_child_from_field")
 
     # a. Child class config overrides prefix
     class Parent(BaseSettings):
-        foobar: str = Field(None, validation_alias='foobar_parent_from_field')
+        foobar: str = Field(None, validation_alias="foobar_parent_from_field")
 
-        model_config = SettingsConfigDict(env_prefix='p_')
+        model_config = SettingsConfigDict(env_prefix="p_")
 
     class Child(Parent):
-        model_config = SettingsConfigDict(env_prefix='prefix_')
+        model_config = SettingsConfigDict(env_prefix="prefix_")
 
-    assert Child().foobar == 'foobar_parent_from_field'
+    assert Child().foobar == "foobar_parent_from_field"
 
     # b. Child class overrides field
     class Parent(BaseSettings):
-        foobar: str = Field(None, validation_alias='foobar_parent_from_config')
+        foobar: str = Field(None, validation_alias="foobar_parent_from_config")
 
     class Child(Parent):
-        foobar: str = Field(None, validation_alias='foobar_child_from_config')
+        foobar: str = Field(None, validation_alias="foobar_child_from_config")
 
-    assert Child().foobar == 'foobar_child_from_config'
+    assert Child().foobar == "foobar_child_from_config"
 
     # . Child class overrides parent prefix and field
     class Parent(BaseSettings):
         foobar: Optional[str]
 
-        model_config = SettingsConfigDict(env_prefix='p_')
+        model_config = SettingsConfigDict(env_prefix="p_")
 
     class Child(Parent):
-        foobar: str = Field(None, validation_alias='foobar_child_from_field')
+        foobar: str = Field(None, validation_alias="foobar_child_from_field")
 
-        model_config = SettingsConfigDict(env_prefix='prefix_')
+        model_config = SettingsConfigDict(env_prefix="prefix_")
 
-    assert Child().foobar == 'foobar_child_from_field'
+    assert Child().foobar == "foobar_child_from_field"
 
 
 def test_invalid_validation_alias(env):
     with pytest.raises(
-        TypeError, match='Invalid `validation_alias` type. it should be `str`, `AliasChoices`, or `AliasPath`'
+        TypeError,
+        match="Invalid `validation_alias` type. it should be `str`, `AliasChoices`, or `AliasPath`",
     ):
 
         class Settings(BaseSettings):
@@ -546,54 +567,58 @@ def test_invalid_validation_alias(env):
 
 def test_validation_aliases(env):
     class Settings(BaseSettings):
-        foobar: str = Field('default value', validation_alias='foobar_alias')
+        foobar: str = Field("default value", validation_alias="foobar_alias")
 
-    assert Settings().foobar == 'default value'
-    assert Settings(foobar_alias='42').foobar == '42'
-    env.set('foobar_alias', 'xxx')
-    assert Settings().foobar == 'xxx'
-    assert Settings(foobar_alias='42').foobar == '42'
+    assert Settings().foobar == "default value"
+    assert Settings(foobar_alias="42").foobar == "42"
+    env.set("foobar_alias", "xxx")
+    assert Settings().foobar == "xxx"
+    assert Settings(foobar_alias="42").foobar == "42"
 
 
 def test_validation_aliases_alias_path(env):
     class Settings(BaseSettings):
-        foobar: str = Field(validation_alias=AliasPath('foo', 'bar', 1))
+        foobar: str = Field(validation_alias=AliasPath("foo", "bar", 1))
 
-    env.set('foo', '{"bar": ["val0", "val1"]}')
-    assert Settings().foobar == 'val1'
+    env.set("foo", '{"bar": ["val0", "val1"]}')
+    assert Settings().foobar == "val1"
 
 
 def test_validation_aliases_alias_choices(env):
     class Settings(BaseSettings):
-        foobar: str = Field(validation_alias=AliasChoices('foo', AliasPath('foo1', 'bar', 1), AliasPath('bar', 2)))
+        foobar: str = Field(
+            validation_alias=AliasChoices(
+                "foo", AliasPath("foo1", "bar", 1), AliasPath("bar", 2)
+            )
+        )
 
-    env.set('foo', 'val1')
-    assert Settings().foobar == 'val1'
+    env.set("foo", "val1")
+    assert Settings().foobar == "val1"
 
-    env.pop('foo')
-    env.set('foo1', '{"bar": ["val0", "val2"]}')
-    assert Settings().foobar == 'val2'
+    env.pop("foo")
+    env.set("foo1", '{"bar": ["val0", "val2"]}')
+    assert Settings().foobar == "val2"
 
-    env.pop('foo1')
-    env.set('bar', '["val1", "val2", "val3"]')
-    assert Settings().foobar == 'val3'
+    env.pop("foo1")
+    env.set("bar", '["val1", "val2", "val3"]')
+    assert Settings().foobar == "val3"
 
 
 def test_validation_alias_with_env_prefix(env):
     class Settings(BaseSettings):
-        foobar: str = Field(validation_alias='foo')
+        foobar: str = Field(validation_alias="foo")
 
-        model_config = SettingsConfigDict(env_prefix='p_')
+        model_config = SettingsConfigDict(env_prefix="p_")
 
-    env.set('p_foo', 'bar')
+    env.set("p_foo", "bar")
     with pytest.raises(ValidationError) as exc_info:
         Settings()
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'missing', 'loc': ('foo',), 'msg': 'Field required', 'input': {}}
+        {"type": "missing", "loc": ("foo",), "msg": "Field required", "input": {}}
     ]
 
-    env.set('foo', 'bar')
-    assert Settings().foobar == 'bar'
+    env.set("foo", "bar")
+    assert Settings().foobar == "bar"
 
 
 def test_case_sensitive(monkeypatch):
@@ -603,11 +628,11 @@ def test_case_sensitive(monkeypatch):
         model_config = SettingsConfigDict(case_sensitive=True)
 
     # Need to patch os.environ to get build to work on Windows, where os.environ is case insensitive
-    monkeypatch.setattr(os, 'environ', value={'Foo': 'foo'})
+    monkeypatch.setattr(os, "environ", value={"Foo": "foo"})
     with pytest.raises(ValidationError) as exc_info:
         Settings()
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'missing', 'loc': ('foo',), 'msg': 'Field required', 'input': {}}
+        {"type": "missing", "loc": ("foo",), "msg": "Field required", "input": {}}
     ]
 
 
@@ -620,11 +645,11 @@ def test_nested_dataclass(env):
     class Settings(BaseSettings):
         n: MyDataclass
 
-    env.set('N', '{"foo": 123, "bar": "bar value"}')
+    env.set("N", '{"foo": 123, "bar": "bar value"}')
     s = Settings()
     assert isinstance(s.n, MyDataclass)
     assert s.n.foo == 123
-    assert s.n.bar == 'bar value'
+    assert s.n.bar == "bar value"
 
 
 def test_env_takes_precedence(env):
@@ -643,11 +668,11 @@ def test_env_takes_precedence(env):
         ) -> Tuple[PydanticBaseSettingsSource, ...]:
             return env_settings, init_settings
 
-    env.set('BAR', 'env setting')
+    env.set("BAR", "env setting")
 
-    s = Settings(foo='123', bar='argument')
+    s = Settings(foo="123", bar="argument")
     assert s.foo == 123
-    assert s.bar == 'env setting'
+    assert s.bar == "env setting"
 
 
 def test_config_file_settings_nornir(env):
@@ -656,7 +681,7 @@ def test_config_file_settings_nornir(env):
     """
 
     def nornir_settings_source() -> Dict[str, Any]:
-        return {'param_a': 'config a', 'param_b': 'config b', 'param_c': 'config c'}
+        return {"param_a": "config a", "param_b": "config b", "param_c": "config c"}
 
     class Settings(BaseSettings):
         param_a: str
@@ -674,12 +699,12 @@ def test_config_file_settings_nornir(env):
         ) -> Tuple[PydanticBaseSettingsSource, ...]:
             return env_settings, init_settings, nornir_settings_source
 
-    env.set('PARAM_C', 'env setting c')
+    env.set("PARAM_C", "env setting c")
 
-    s = Settings(param_b='argument b', param_c='argument c')
-    assert s.param_a == 'config a'
-    assert s.param_b == 'argument b'
-    assert s.param_c == 'env setting c'
+    s = Settings(param_b="argument b", param_c="argument c")
+    assert s.param_a == "config a"
+    assert s.param_b == "argument b"
+    assert s.param_c == "env setting c"
 
 
 def test_env_union_with_complex_subfields_parses_json(env):
@@ -692,9 +717,9 @@ def test_env_union_with_complex_subfields_parses_json(env):
     class Settings(BaseSettings):
         content: Union[A, B, int]
 
-    env.set('content', '{"a": "test"}')
+    env.set("content", '{"a": "test"}')
     s = Settings()
-    assert s.content == A(a='test')
+    assert s.content == A(a="test")
 
 
 def test_env_union_with_complex_subfields_parses_plain_if_json_fails(env):
@@ -707,11 +732,11 @@ def test_env_union_with_complex_subfields_parses_plain_if_json_fails(env):
     class Settings(BaseSettings):
         content: Union[A, B, datetime]
 
-    env.set('content', '{"a": "test"}')
+    env.set("content", '{"a": "test"}')
     s = Settings()
-    assert s.content == A(a='test')
+    assert s.content == A(a="test")
 
-    env.set('content', '2020-07-05T00:00:00Z')
+    env.set("content", "2020-07-05T00:00:00Z")
     s = Settings()
     assert s.content == datetime(2020, 7, 5, 0, 0, tzinfo=timezone.utc)
 
@@ -720,9 +745,9 @@ def test_env_union_without_complex_subfields_does_not_parse_json(env):
     class Settings(BaseSettings):
         content: Union[datetime, str]
 
-    env.set('content', '2020-07-05T00:00:00Z')
+    env.set("content", "2020-07-05T00:00:00Z")
     s = Settings()
-    assert s.content == '2020-07-05T00:00:00Z'
+    assert s.content == "2020-07-05T00:00:00Z"
 
 
 test_env_file = """\
@@ -736,7 +761,7 @@ c="best string"
 
 
 def test_env_file_config(env, tmp_path):
-    p = tmp_path / '.env'
+    p = tmp_path / ".env"
     p.write_text(test_env_file)
 
     class Settings(BaseSettings):
@@ -746,12 +771,12 @@ def test_env_file_config(env, tmp_path):
 
         model_config = SettingsConfigDict(env_file=p)
 
-    env.set('A', 'overridden var')
+    env.set("A", "overridden var")
 
     s = Settings()
-    assert s.a == 'overridden var'
-    assert s.b == 'better string'
-    assert s.c == 'best string'
+    assert s.a == "overridden var"
+    assert s.b == "better string"
+    assert s.c == "best string"
 
 
 prefix_test_env_file = """\
@@ -765,7 +790,7 @@ prefix_c="best string"
 
 
 def test_env_file_with_env_prefix(env, tmp_path):
-    p = tmp_path / '.env'
+    p = tmp_path / ".env"
     p.write_text(prefix_test_env_file)
 
     class Settings(BaseSettings):
@@ -773,14 +798,14 @@ def test_env_file_with_env_prefix(env, tmp_path):
         b: str
         c: str
 
-        model_config = SettingsConfigDict(env_file=p, env_prefix='prefix_')
+        model_config = SettingsConfigDict(env_file=p, env_prefix="prefix_")
 
-    env.set('prefix_A', 'overridden var')
+    env.set("prefix_A", "overridden var")
 
     s = Settings()
-    assert s.a == 'overridden var'
-    assert s.b == 'better string'
-    assert s.c == 'best string'
+    assert s.a == "overridden var"
+    assert s.b == "better string"
+    assert s.c == "best string"
 
 
 prefix_test_env_invalid_file = """\
@@ -795,7 +820,7 @@ f="random value"
 
 
 def test_env_file_with_env_prefix_invalid(tmp_path):
-    p = tmp_path / '.env'
+    p = tmp_path / ".env"
     p.write_text(prefix_test_env_invalid_file)
 
     class Settings(BaseSettings):
@@ -803,17 +828,22 @@ def test_env_file_with_env_prefix_invalid(tmp_path):
         b: str
         c: str
 
-        model_config = SettingsConfigDict(env_file=p, env_prefix='prefix_')
+        model_config = SettingsConfigDict(env_file=p, env_prefix="prefix_")
 
     with pytest.raises(ValidationError) as exc_info:
         Settings()
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'extra_forbidden', 'loc': ('f',), 'msg': 'Extra inputs are not permitted', 'input': 'random value'}
+        {
+            "type": "extra_forbidden",
+            "loc": ("f",),
+            "msg": "Extra inputs are not permitted",
+            "input": "random value",
+        }
     ]
 
 
 def test_ignore_env_file_with_env_prefix_invalid(tmp_path):
-    p = tmp_path / '.env'
+    p = tmp_path / ".env"
     p.write_text(prefix_test_env_invalid_file)
 
     class Settings(BaseSettings):
@@ -821,17 +851,19 @@ def test_ignore_env_file_with_env_prefix_invalid(tmp_path):
         b: str
         c: str
 
-        model_config = SettingsConfigDict(env_file=p, env_prefix='prefix_', extra='ignore')
+        model_config = SettingsConfigDict(
+            env_file=p, env_prefix="prefix_", extra="ignore"
+        )
 
     s = Settings()
 
-    assert s.a == 'good string'
-    assert s.b == 'better string'
-    assert s.c == 'best string'
+    assert s.a == "good string"
+    assert s.b == "better string"
+    assert s.c == "best string"
 
 
 def test_env_file_config_case_sensitive(tmp_path):
-    p = tmp_path / '.env'
+    p = tmp_path / ".env"
     p.write_text(test_env_file)
 
     class Settings(BaseSettings):
@@ -839,22 +871,24 @@ def test_env_file_config_case_sensitive(tmp_path):
         b: str
         c: str
 
-        model_config = SettingsConfigDict(env_file=p, case_sensitive=True, extra='ignore')
+        model_config = SettingsConfigDict(
+            env_file=p, case_sensitive=True, extra="ignore"
+        )
 
     with pytest.raises(ValidationError) as exc_info:
         Settings()
     assert exc_info.value.errors(include_url=False) == [
         {
-            'type': 'missing',
-            'loc': ('a',),
-            'msg': 'Field required',
-            'input': {'b': 'better string', 'c': 'best string', 'A': 'good string'},
+            "type": "missing",
+            "loc": ("a",),
+            "msg": "Field required",
+            "input": {"b": "better string", "c": "best string", "A": "good string"},
         }
     ]
 
 
 def test_env_file_export(env, tmp_path):
-    p = tmp_path / '.env'
+    p = tmp_path / ".env"
     p.write_text(
         """\
 export A='good string'
@@ -870,43 +904,43 @@ export C="best string"
 
         model_config = SettingsConfigDict(env_file=p)
 
-    env.set('A', 'overridden var')
+    env.set("A", "overridden var")
 
     s = Settings()
-    assert s.a == 'overridden var'
-    assert s.b == 'better-string'
-    assert s.c == 'best string'
+    assert s.a == "overridden var"
+    assert s.b == "better-string"
+    assert s.c == "best string"
 
 
 def test_env_file_export_validation_alias(env, tmp_path):
-    p = tmp_path / '.env'
+    p = tmp_path / ".env"
     p.write_text("""export a='{"b": ["1", "2"]}'""")
 
     class Settings(BaseSettings):
-        a: str = Field(validation_alias=AliasChoices(AliasPath('a', 'b', 1)))
+        a: str = Field(validation_alias=AliasChoices(AliasPath("a", "b", 1)))
 
         model_config = SettingsConfigDict(env_file=p)
 
     s = Settings()
-    assert s.a == '2'
+    assert s.a == "2"
 
 
 def test_env_file_config_custom_encoding(tmp_path):
-    p = tmp_path / '.env'
-    p.write_text('pika=p!±@', encoding='latin-1')
+    p = tmp_path / ".env"
+    p.write_text("pika=p!±@", encoding="latin-1")
 
     class Settings(BaseSettings):
         pika: str
 
-        model_config = SettingsConfigDict(env_file=p, env_file_encoding='latin-1')
+        model_config = SettingsConfigDict(env_file=p, env_file_encoding="latin-1")
 
     s = Settings()
-    assert s.pika == 'p!±@'
+    assert s.pika == "p!±@"
 
 
 @pytest.fixture
 def home_tmp():
-    tmp_filename = f'{uuid.uuid4()}.env'
+    tmp_filename = f"{uuid.uuid4()}.env"
     home_tmp_path = Path.home() / tmp_filename
     yield home_tmp_path, tmp_filename
     home_tmp_path.unlink()
@@ -914,31 +948,31 @@ def home_tmp():
 
 def test_env_file_home_directory(home_tmp):
     home_tmp_path, tmp_filename = home_tmp
-    home_tmp_path.write_text('pika=baz')
+    home_tmp_path.write_text("pika=baz")
 
     class Settings(BaseSettings):
         pika: str
 
-        model_config = SettingsConfigDict(env_file=f'~/{tmp_filename}')
+        model_config = SettingsConfigDict(env_file=f"~/{tmp_filename}")
 
-    assert Settings().pika == 'baz'
+    assert Settings().pika == "baz"
 
 
 def test_env_file_none(tmp_path):
-    p = tmp_path / '.env'
-    p.write_text('a')
+    p = tmp_path / ".env"
+    p.write_text("a")
 
     class Settings(BaseSettings):
-        a: str = 'xxx'
+        a: str = "xxx"
 
     s = Settings(_env_file=p)
-    assert s.a == 'xxx'
+    assert s.a == "xxx"
 
 
 def test_env_file_override_file(tmp_path):
-    p1 = tmp_path / '.env'
+    p1 = tmp_path / ".env"
     p1.write_text(test_env_file)
-    p2 = tmp_path / '.env.prod'
+    p2 = tmp_path / ".env.prod"
     p2.write_text('A="new string"')
 
     class Settings(BaseSettings):
@@ -947,11 +981,11 @@ def test_env_file_override_file(tmp_path):
         model_config = SettingsConfigDict(env_file=str(p1))
 
     s = Settings(_env_file=p2)
-    assert s.a == 'new string'
+    assert s.a == "new string"
 
 
 def test_env_file_override_none(tmp_path):
-    p = tmp_path / '.env'
+    p = tmp_path / ".env"
     p.write_text(test_env_file)
 
     class Settings(BaseSettings):
@@ -967,28 +1001,28 @@ def test_env_file_not_a_file(env):
     class Settings(BaseSettings):
         a: str = None
 
-    env.set('A', 'ignore non-file')
-    s = Settings(_env_file='tests/')
-    assert s.a == 'ignore non-file'
+    env.set("A", "ignore non-file")
+    s = Settings(_env_file="tests/")
+    assert s.a == "ignore non-file"
 
 
 def test_read_env_file_case_sensitive(tmp_path):
-    p = tmp_path / '.env'
+    p = tmp_path / ".env"
     p.write_text('a="test"\nB=123')
 
-    assert read_env_file(p) == {'a': 'test', 'b': '123'}
-    assert read_env_file(p, case_sensitive=True) == {'a': 'test', 'B': '123'}
+    assert read_env_file(p) == {"a": "test", "b": "123"}
+    assert read_env_file(p, case_sensitive=True) == {"a": "test", "B": "123"}
 
 
 def test_read_env_file_syntax_wrong(tmp_path):
-    p = tmp_path / '.env'
-    p.write_text('NOT_AN_ASSIGNMENT')
+    p = tmp_path / ".env"
+    p.write_text("NOT_AN_ASSIGNMENT")
 
-    assert read_env_file(p, case_sensitive=True) == {'NOT_AN_ASSIGNMENT': None}
+    assert read_env_file(p, case_sensitive=True) == {"NOT_AN_ASSIGNMENT": None}
 
 
 def test_env_file_example(tmp_path):
-    p = tmp_path / '.env'
+    p = tmp_path / ".env"
     p.write_text(
         """\
 # ignore comment
@@ -1007,16 +1041,16 @@ MY_VAR='Hello world'
 
     s = Settings(_env_file=str(p))
     assert s.model_dump() == {
-        'environment': 'production',
-        'redis_address': 'localhost:6379',
-        'meaning_of_life': 42,
-        'my_var': 'Hello world',
+        "environment": "production",
+        "redis_address": "localhost:6379",
+        "meaning_of_life": 42,
+        "my_var": "Hello world",
     }
 
 
 def test_env_file_custom_encoding(tmp_path):
-    p = tmp_path / '.env'
-    p.write_text('pika=p!±@', encoding='latin-1')
+    p = tmp_path / ".env"
+    p.write_text("pika=p!±@", encoding="latin-1")
 
     class Settings(BaseSettings):
         pika: str
@@ -1024,8 +1058,8 @@ def test_env_file_custom_encoding(tmp_path):
     with pytest.raises(UnicodeDecodeError):
         Settings(_env_file=str(p))
 
-    s = Settings(_env_file=str(p), _env_file_encoding='latin-1')
-    assert s.model_dump() == {'pika': 'p!±@'}
+    s = Settings(_env_file=str(p), _env_file_encoding="latin-1")
+    assert s.model_dump() == {"pika": "p!±@"}
 
 
 test_default_env_file = """\
@@ -1041,9 +1075,9 @@ host=https://example.com/services
 
 
 def test_multiple_env_file(tmp_path):
-    base_env = tmp_path / '.env'
+    base_env = tmp_path / ".env"
     base_env.write_text(test_default_env_file)
-    prod_env = tmp_path / '.env.prod'
+    prod_env = tmp_path / ".env.prod"
     prod_env.write_text(test_prod_env_file)
 
     class Settings(BaseSettings):
@@ -1055,14 +1089,14 @@ def test_multiple_env_file(tmp_path):
 
     s = Settings()
     assert s.debug_mode is False
-    assert s.host == 'https://example.com/services'
+    assert s.host == "https://example.com/services"
     assert s.port == 8000
 
 
 def test_model_env_file_override_model_config(tmp_path):
-    base_env = tmp_path / '.env'
+    base_env = tmp_path / ".env"
     base_env.write_text(test_default_env_file)
-    prod_env = tmp_path / '.env.prod'
+    prod_env = tmp_path / ".env.prod"
     prod_env.write_text(test_prod_env_file)
 
     class Settings(BaseSettings):
@@ -1074,45 +1108,51 @@ def test_model_env_file_override_model_config(tmp_path):
 
     s = Settings(_env_file=base_env)
     assert s.debug_mode is True
-    assert s.host == 'localhost'
+    assert s.host == "localhost"
     assert s.port == 8000
 
 
 def test_multiple_env_file_encoding(tmp_path):
-    base_env = tmp_path / '.env'
-    base_env.write_text('pika=p!±@', encoding='latin-1')
-    prod_env = tmp_path / '.env.prod'
-    prod_env.write_text('pika=chu!±@', encoding='latin-1')
+    base_env = tmp_path / ".env"
+    base_env.write_text("pika=p!±@", encoding="latin-1")
+    prod_env = tmp_path / ".env.prod"
+    prod_env.write_text("pika=chu!±@", encoding="latin-1")
 
     class Settings(BaseSettings):
         pika: str
 
-    s = Settings(_env_file=[base_env, prod_env], _env_file_encoding='latin-1')
-    assert s.pika == 'chu!±@'
+    s = Settings(_env_file=[base_env, prod_env], _env_file_encoding="latin-1")
+    assert s.pika == "chu!±@"
 
 
 def test_read_dotenv_vars(tmp_path):
-    base_env = tmp_path / '.env'
+    base_env = tmp_path / ".env"
     base_env.write_text(test_default_env_file)
-    prod_env = tmp_path / '.env.prod'
+    prod_env = tmp_path / ".env.prod"
     prod_env.write_text(test_prod_env_file)
 
     source = DotEnvSettingsSource(
-        BaseSettings(), env_file=[base_env, prod_env], env_file_encoding='utf8', case_sensitive=False
+        BaseSettings(),
+        env_file=[base_env, prod_env],
+        env_file_encoding="utf8",
+        case_sensitive=False,
     )
     assert source._read_env_files() == {
-        'debug_mode': 'false',
-        'host': 'https://example.com/services',
-        'port': '8000',
+        "debug_mode": "false",
+        "host": "https://example.com/services",
+        "port": "8000",
     }
 
     source = DotEnvSettingsSource(
-        BaseSettings(), env_file=[base_env, prod_env], env_file_encoding='utf8', case_sensitive=True
+        BaseSettings(),
+        env_file=[base_env, prod_env],
+        env_file_encoding="utf8",
+        case_sensitive=True,
     )
     assert source._read_env_files() == {
-        'debug_mode': 'false',
-        'host': 'https://example.com/services',
-        'Port': '8000',
+        "debug_mode": "false",
+        "host": "https://example.com/services",
+        "Port": "8000",
     }
 
 
@@ -1125,9 +1165,9 @@ def test_read_dotenv_vars_when_env_file_is_none():
     )
 
 
-@pytest.mark.skipif(yaml, reason='PyYAML is installed')
+@pytest.mark.skipif(yaml, reason="PyYAML is installed")
 def test_yaml_not_installed(tmp_path):
-    p = tmp_path / '.env'
+    p = tmp_path / ".env"
     p.write_text(
         """
     foobar: "Hello"
@@ -1149,88 +1189,103 @@ def test_yaml_not_installed(tmp_path):
         ) -> Tuple[PydanticBaseSettingsSource, ...]:
             return (YamlConfigSettingsSource(settings_cls),)
 
-    with pytest.raises(ImportError, match=r'^PyYAML is not installed, run `pip install pydantic-settings\[yaml\]`$'):
+    with pytest.raises(
+        ImportError,
+        match=r"^PyYAML is not installed, run `pip install pydantic-settings\[yaml\]`$",
+    ):
         Settings()
 
 
 def test_alias_set(env):
     class Settings(BaseSettings):
-        foo: str = Field('default foo', validation_alias='foo_env')
-        bar: str = 'bar default'
+        foo: str = Field("default foo", validation_alias="foo_env")
+        bar: str = "bar default"
 
-    assert Settings.model_fields['bar'].alias is None
-    assert Settings.model_fields['bar'].validation_alias is None
-    assert Settings.model_fields['foo'].alias is None
-    assert Settings.model_fields['foo'].validation_alias == 'foo_env'
+    assert Settings.model_fields["bar"].alias is None
+    assert Settings.model_fields["bar"].validation_alias is None
+    assert Settings.model_fields["foo"].alias is None
+    assert Settings.model_fields["foo"].validation_alias == "foo_env"
 
     class SubSettings(Settings):
-        spam: str = 'spam default'
+        spam: str = "spam default"
 
-    assert SubSettings.model_fields['bar'].alias is None
-    assert SubSettings.model_fields['bar'].validation_alias is None
-    assert SubSettings.model_fields['foo'].alias is None
-    assert SubSettings.model_fields['foo'].validation_alias == 'foo_env'
+    assert SubSettings.model_fields["bar"].alias is None
+    assert SubSettings.model_fields["bar"].validation_alias is None
+    assert SubSettings.model_fields["foo"].alias is None
+    assert SubSettings.model_fields["foo"].validation_alias == "foo_env"
 
-    assert SubSettings().model_dump() == {'foo': 'default foo', 'bar': 'bar default', 'spam': 'spam default'}
-    env.set('foo_env', 'fff')
-    assert SubSettings().model_dump() == {'foo': 'fff', 'bar': 'bar default', 'spam': 'spam default'}
-    env.set('bar', 'bbb')
-    assert SubSettings().model_dump() == {'foo': 'fff', 'bar': 'bbb', 'spam': 'spam default'}
-    env.set('spam', 'sss')
-    assert SubSettings().model_dump() == {'foo': 'fff', 'bar': 'bbb', 'spam': 'sss'}
+    assert SubSettings().model_dump() == {
+        "foo": "default foo",
+        "bar": "bar default",
+        "spam": "spam default",
+    }
+    env.set("foo_env", "fff")
+    assert SubSettings().model_dump() == {
+        "foo": "fff",
+        "bar": "bar default",
+        "spam": "spam default",
+    }
+    env.set("bar", "bbb")
+    assert SubSettings().model_dump() == {
+        "foo": "fff",
+        "bar": "bbb",
+        "spam": "spam default",
+    }
+    env.set("spam", "sss")
+    assert SubSettings().model_dump() == {"foo": "fff", "bar": "bbb", "spam": "sss"}
 
 
 def test_prefix_on_parent(env):
     class MyBaseSettings(BaseSettings):
-        var: str = 'old'
+        var: str = "old"
 
     class MySubSettings(MyBaseSettings):
-        model_config = SettingsConfigDict(env_prefix='PREFIX_')
+        model_config = SettingsConfigDict(env_prefix="PREFIX_")
 
-    assert MyBaseSettings().model_dump() == {'var': 'old'}
-    assert MySubSettings().model_dump() == {'var': 'old'}
-    env.set('PREFIX_VAR', 'new')
-    assert MyBaseSettings().model_dump() == {'var': 'old'}
-    assert MySubSettings().model_dump() == {'var': 'new'}
+    assert MyBaseSettings().model_dump() == {"var": "old"}
+    assert MySubSettings().model_dump() == {"var": "old"}
+    env.set("PREFIX_VAR", "new")
+    assert MyBaseSettings().model_dump() == {"var": "old"}
+    assert MySubSettings().model_dump() == {"var": "new"}
 
 
 def test_secrets_path(tmp_path):
-    p = tmp_path / 'foo'
-    p.write_text('foo_secret_value_str')
+    p = tmp_path / "foo"
+    p.write_text("foo_secret_value_str")
 
     class Settings(BaseSettings):
         foo: str
 
         model_config = SettingsConfigDict(secrets_dir=tmp_path)
 
-    assert Settings().model_dump() == {'foo': 'foo_secret_value_str'}
+    assert Settings().model_dump() == {"foo": "foo_secret_value_str"}
 
 
 def test_secrets_path_with_validation_alias(tmp_path):
-    p = tmp_path / 'foo'
+    p = tmp_path / "foo"
     p.write_text('{"bar": ["test"]}')
 
     class Settings(BaseSettings):
-        foo: str = Field(validation_alias=AliasChoices(AliasPath('foo', 'bar', 0)))
+        foo: str = Field(validation_alias=AliasChoices(AliasPath("foo", "bar", 0)))
 
         model_config = SettingsConfigDict(secrets_dir=tmp_path)
 
-    assert Settings().model_dump() == {'foo': 'test'}
+    assert Settings().model_dump() == {"foo": "test"}
 
 
 def test_secrets_case_sensitive(tmp_path):
-    (tmp_path / 'SECRET_VAR').write_text('foo_env_value_str')
+    (tmp_path / "SECRET_VAR").write_text("foo_env_value_str")
 
     class Settings(BaseSettings):
         secret_var: Optional[str] = None
 
         model_config = SettingsConfigDict(secrets_dir=tmp_path, case_sensitive=True)
 
-    assert Settings().model_dump() == {'secret_var': None}
+    assert Settings().model_dump() == {"secret_var": None}
 
 
 def test_secrets_case_insensitive(tmp_path):
-    (tmp_path / 'SECRET_VAR').write_text('foo_env_value_str')
+    (tmp_path / "SECRET_VAR").write_text("foo_env_value_str")
 
     class Settings(BaseSettings):
         secret_var: Optional[str]
@@ -1238,12 +1293,12 @@ def test_secrets_case_insensitive(tmp_path):
         model_config = SettingsConfigDict(secrets_dir=tmp_path, case_sensitive=False)
 
     settings = Settings().model_dump()
-    assert settings == {'secret_var': 'foo_env_value_str'}
+    assert settings == {"secret_var": "foo_env_value_str"}
 
 
 def test_secrets_path_url(tmp_path):
-    (tmp_path / 'foo').write_text('http://www.example.com')
-    (tmp_path / 'bar').write_text('snap')
+    (tmp_path / "foo").write_text("http://www.example.com")
+    (tmp_path / "bar").write_text("snap")
 
     class Settings(BaseSettings):
         foo: HttpUrl
@@ -1252,12 +1307,12 @@ def test_secrets_path_url(tmp_path):
         model_config = SettingsConfigDict(secrets_dir=tmp_path)
 
     settings = Settings()
-    assert str(settings.foo) == 'http://www.example.com/'
-    assert settings.bar == SecretStr('snap')
+    assert str(settings.foo) == "http://www.example.com/"
+    assert settings.bar == SecretStr("snap")
 
 
 def test_secrets_path_json(tmp_path):
-    p = tmp_path / 'foo'
+    p = tmp_path / "foo"
     p.write_text('{"a": "b"}')
 
     class Settings(BaseSettings):
@@ -1265,11 +1320,11 @@ def test_secrets_path_json(tmp_path):
 
         model_config = SettingsConfigDict(secrets_dir=tmp_path)
 
-    assert Settings().model_dump() == {'foo': {'a': 'b'}}
+    assert Settings().model_dump() == {"foo": {"a": "b"}}
 
 
 def test_secrets_nested_optional_json(tmp_path):
-    p = tmp_path / 'foo'
+    p = tmp_path / "foo"
     p.write_text('{"a": 10}')
 
     class Foo(BaseModel):
@@ -1280,11 +1335,11 @@ def test_secrets_nested_optional_json(tmp_path):
 
         model_config = SettingsConfigDict(secrets_dir=tmp_path)
 
-    assert Settings().model_dump() == {'foo': {'a': 10}}
+    assert Settings().model_dump() == {"foo": {"a": 10}}
 
 
 def test_secrets_path_invalid_json(tmp_path):
-    p = tmp_path / 'foo'
+    p = tmp_path / "foo"
     p.write_text('{"a": "b"')
 
     class Settings(BaseSettings):
@@ -1292,7 +1347,10 @@ def test_secrets_path_invalid_json(tmp_path):
 
         model_config = SettingsConfigDict(secrets_dir=tmp_path)
 
-    with pytest.raises(SettingsError, match='error parsing value for field "foo" from source "SecretsSettingsSource"'):
+    with pytest.raises(
+        SettingsError,
+        match='error parsing value for field "foo" from source "SecretsSettingsSource"',
+    ):
         Settings()
 
 
@@ -1307,36 +1365,40 @@ def test_secrets_missing(tmp_path):
         Settings()
 
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'missing', 'loc': ('foo',), 'msg': 'Field required', 'input': {}},
-        {'input': {}, 'loc': ('bar',), 'msg': 'Field required', 'type': 'missing'},
+        {"type": "missing", "loc": ("foo",), "msg": "Field required", "input": {}},
+        {"input": {}, "loc": ("bar",), "msg": "Field required", "type": "missing"},
     ]
 
 
 def test_secrets_invalid_secrets_dir(tmp_path):
-    p1 = tmp_path / 'foo'
-    p1.write_text('foo_secret_value_str')
+    p1 = tmp_path / "foo"
+    p1.write_text("foo_secret_value_str")
 
     class Settings(BaseSettings):
         foo: str
 
         model_config = SettingsConfigDict(secrets_dir=p1)
 
-    with pytest.raises(SettingsError, match='secrets_dir must reference a directory, not a file'):
+    with pytest.raises(
+        SettingsError, match="secrets_dir must reference a directory, not a file"
+    ):
         Settings()
 
 
-@pytest.mark.skipif(sys.platform.startswith('win'), reason='windows paths break regex')
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="windows paths break regex")
 def test_secrets_missing_location(tmp_path):
     class Settings(BaseSettings):
-        model_config = SettingsConfigDict(secrets_dir=tmp_path / 'does_not_exist')
+        model_config = SettingsConfigDict(secrets_dir=tmp_path / "does_not_exist")
 
-    with pytest.warns(UserWarning, match=f'directory "{tmp_path}/does_not_exist" does not exist'):
+    with pytest.warns(
+        UserWarning, match=f'directory "{tmp_path}/does_not_exist" does not exist'
+    ):
         Settings()
 
 
-@pytest.mark.skipif(sys.platform.startswith('win'), reason='windows paths break regex')
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="windows paths break regex")
 def test_secrets_file_is_a_directory(tmp_path):
-    p1 = tmp_path / 'foo'
+    p1 = tmp_path / "foo"
     p1.mkdir()
 
     class Settings(BaseSettings):
@@ -1344,31 +1406,34 @@ def test_secrets_file_is_a_directory(tmp_path):
 
         model_config = SettingsConfigDict(secrets_dir=tmp_path)
 
-    with pytest.warns(UserWarning, match=f'attempted to load secret file "{tmp_path}/foo" but found a directory inste'):
+    with pytest.warns(
+        UserWarning,
+        match=f'attempted to load secret file "{tmp_path}/foo" but found a directory inste',
+    ):
         Settings()
 
 
 def test_secrets_dotenv_precedence(tmp_path):
-    s = tmp_path / 'foo'
-    s.write_text('foo_secret_value_str')
+    s = tmp_path / "foo"
+    s.write_text("foo_secret_value_str")
 
-    e = tmp_path / '.env'
-    e.write_text('foo=foo_env_value_str')
+    e = tmp_path / ".env"
+    e.write_text("foo=foo_env_value_str")
 
     class Settings(BaseSettings):
         foo: str
 
         model_config = SettingsConfigDict(secrets_dir=tmp_path)
 
-    assert Settings(_env_file=e).model_dump() == {'foo': 'foo_env_value_str'}
+    assert Settings(_env_file=e).model_dump() == {"foo": "foo_env_value_str"}
 
 
 def test_external_settings_sources_precedence(env):
     def external_source_0() -> Dict[str, str]:
-        return {'apple': 'value 0', 'banana': 'value 2'}
+        return {"apple": "value 0", "banana": "value 2"}
 
     def external_source_1() -> Dict[str, str]:
-        return {'apple': 'value 1', 'raspberry': 'value 3'}
+        return {"apple": "value 1", "raspberry": "value 3"}
 
     class Settings(BaseSettings):
         apple: str
@@ -1393,12 +1458,16 @@ def test_external_settings_sources_precedence(env):
                 external_source_1,
             )
 
-    env.set('banana', 'value 1')
-    assert Settings().model_dump() == {'apple': 'value 0', 'banana': 'value 1', 'raspberry': 'value 3'}
+    env.set("banana", "value 1")
+    assert Settings().model_dump() == {
+        "apple": "value 0",
+        "banana": "value 1",
+        "raspberry": "value 3",
+    }
 
 
 def test_external_settings_sources_filter_env_vars():
-    vault_storage = {'user:password': {'apple': 'value 0', 'banana': 'value 2'}}
+    vault_storage = {"user:password": {"apple": "value 0", "banana": "value 2"}}
 
     class VaultSettingsSource(PydanticBaseSettingsSource):
         def __init__(self, settings_cls: Type[BaseSettings], user: str, password: str):
@@ -1410,7 +1479,7 @@ def test_external_settings_sources_filter_env_vars():
             pass
 
         def __call__(self) -> Dict[str, str]:
-            vault_vars = vault_storage[f'{self.user}:{self.password}']
+            vault_vars = vault_storage[f"{self.user}:{self.password}"]
             return {
                 field_name: vault_vars[field_name]
                 for field_name in self.settings_cls.model_fields.keys()
@@ -1435,40 +1504,49 @@ def test_external_settings_sources_filter_env_vars():
                 env_settings,
                 dotenv_settings,
                 file_secret_settings,
-                VaultSettingsSource(settings_cls, user='user', password='password'),
+                VaultSettingsSource(settings_cls, user="user", password="password"),
             )
 
-    assert Settings().model_dump() == {'apple': 'value 0', 'banana': 'value 2'}
+    assert Settings().model_dump() == {"apple": "value 0", "banana": "value 2"}
 
 
 def test_customise_sources_empty():
     class Settings(BaseSettings):
-        apple: str = 'default'
-        banana: str = 'default'
+        apple: str = "default"
+        banana: str = "default"
 
         @classmethod
         def settings_customise_sources(cls, *args, **kwargs):
             return ()
 
-    assert Settings().model_dump() == {'apple': 'default', 'banana': 'default'}
-    assert Settings(apple='xxx').model_dump() == {'apple': 'default', 'banana': 'default'}
+    assert Settings().model_dump() == {"apple": "default", "banana": "default"}
+    assert Settings(apple="xxx").model_dump() == {
+        "apple": "default",
+        "banana": "default",
+    }
 
 
 def test_builtins_settings_source_repr():
     assert (
-        repr(InitSettingsSource(BaseSettings, init_kwargs={'apple': 'value 0', 'banana': 'value 1'}))
+        repr(
+            InitSettingsSource(
+                BaseSettings, init_kwargs={"apple": "value 0", "banana": "value 1"}
+            )
+        )
         == "InitSettingsSource(init_kwargs={'apple': 'value 0', 'banana': 'value 1'})"
     )
     assert (
-        repr(EnvSettingsSource(BaseSettings, env_nested_delimiter='__'))
+        repr(EnvSettingsSource(BaseSettings, env_nested_delimiter="__"))
         == "EnvSettingsSource(env_nested_delimiter='__', env_prefix_len=0)"
     )
-    assert repr(DotEnvSettingsSource(BaseSettings, env_file='.env', env_file_encoding='utf-8')) == (
+    assert repr(
+        DotEnvSettingsSource(BaseSettings, env_file=".env", env_file_encoding="utf-8")
+    ) == (
         "DotEnvSettingsSource(env_file='.env', env_file_encoding='utf-8', "
-        'env_nested_delimiter=None, env_prefix_len=0)'
+        "env_nested_delimiter=None, env_prefix_len=0)"
     )
     assert (
-        repr(SecretsSettingsSource(BaseSettings, secrets_dir='/secrets'))
+        repr(SecretsSettingsSource(BaseSettings, secrets_dir="/secrets"))
         == "SecretsSettingsSource(secrets_dir='/secrets')"
     )
 
@@ -1476,14 +1554,16 @@ def test_builtins_settings_source_repr():
 def _parse_custom_dict(value: str) -> Callable[[str], Dict[int, str]]:
     """A custom parsing function passed into env parsing test."""
     res = {}
-    for part in value.split(','):
-        k, v = part.split('=')
+    for part in value.split(","):
+        k, v = part.split("=")
         res[int(k)] = v
     return res
 
 
 class CustomEnvSettingsSource(EnvSettingsSource):
-    def prepare_field_value(self, field_name: str, field: FieldInfo, value: Any, value_is_complex: bool) -> Any:
+    def prepare_field_value(
+        self, field_name: str, field: FieldInfo, value: Any, value_is_complex: bool
+    ) -> Any:
         if not value:
             return None
 
@@ -1507,13 +1587,15 @@ def test_env_setting_source_custom_env_parse(env):
 
     with pytest.raises(ValidationError):
         Settings()
-    env.set('top', '1=apple,2=banana')
+    env.set("top", "1=apple,2=banana")
     s = Settings()
-    assert s.top == {1: 'apple', 2: 'banana'}
+    assert s.top == {1: "apple", 2: "banana"}
 
 
 class BadCustomEnvSettingsSource(EnvSettingsSource):
-    def prepare_field_value(self, field_name: str, field: FieldInfo, value: Any, value_is_complex: bool) -> Any:
+    def prepare_field_value(
+        self, field_name: str, field: FieldInfo, value: Any, value_is_complex: bool
+    ) -> Any:
         """A custom parsing function passed into env parsing test."""
         return int(value)
 
@@ -1533,15 +1615,18 @@ def test_env_settings_source_custom_env_parse_is_bad(env):
         ) -> Tuple[PydanticBaseSettingsSource, ...]:
             return (BadCustomEnvSettingsSource(settings_cls),)
 
-    env.set('top', '1=apple,2=banana')
+    env.set("top", "1=apple,2=banana")
     with pytest.raises(
-        SettingsError, match='error parsing value for field "top" from source "BadCustomEnvSettingsSource"'
+        SettingsError,
+        match='error parsing value for field "top" from source "BadCustomEnvSettingsSource"',
     ):
         Settings()
 
 
 class CustomSecretsSettingsSource(SecretsSettingsSource):
-    def prepare_field_value(self, field_name: str, field: FieldInfo, value: Any, value_is_complex: bool) -> Any:
+    def prepare_field_value(
+        self, field_name: str, field: FieldInfo, value: Any, value_is_complex: bool
+    ) -> Any:
         if not value:
             return None
 
@@ -1549,8 +1634,8 @@ class CustomSecretsSettingsSource(SecretsSettingsSource):
 
 
 def test_secret_settings_source_custom_env_parse(tmp_path):
-    p = tmp_path / 'top'
-    p.write_text('1=apple,2=banana')
+    p = tmp_path / "top"
+    p.write_text("1=apple,2=banana")
 
     class Settings(BaseSettings):
         top: Dict[int, str]
@@ -1568,12 +1653,12 @@ def test_secret_settings_source_custom_env_parse(tmp_path):
             return (CustomSecretsSettingsSource(settings_cls, tmp_path),)
 
     s = Settings()
-    assert s.top == {1: 'apple', 2: 'banana'}
+    assert s.top == {1: "apple", 2: "banana"}
 
 
 class BadCustomSettingsSource(EnvSettingsSource):
     def get_field_value(self, field: FieldInfo, field_name: str) -> Any:
-        raise ValueError('Error')
+        raise ValueError("Error")
 
 
 def test_custom_source_get_field_value_error(env):
@@ -1592,7 +1677,8 @@ def test_custom_source_get_field_value_error(env):
             return (BadCustomSettingsSource(settings_cls),)
 
     with pytest.raises(
-        SettingsError, match='error getting value for field "top" from source "BadCustomSettingsSource"'
+        SettingsError,
+        match='error getting value for field "top" from source "BadCustomSettingsSource"',
     ):
         Settings()
 
@@ -1608,16 +1694,19 @@ def test_nested_env_complex_values(env):
     class Cfg(BaseSettings):
         sub_model: SubModel
 
-        model_config = SettingsConfigDict(env_prefix='cfg_', env_nested_delimiter='__')
+        model_config = SettingsConfigDict(env_prefix="cfg_", env_nested_delimiter="__")
 
-    env.set('cfg_sub_model__vals', '["one", "two"]')
-    env.set('cfg_sub_model__sub_sub_model__dvals', '{"three": 4}')
+    env.set("cfg_sub_model__vals", '["one", "two"]')
+    env.set("cfg_sub_model__sub_sub_model__dvals", '{"three": 4}')
 
-    assert Cfg().model_dump() == {'sub_model': {'vals': ['one', 'two'], 'sub_sub_model': {'dvals': {'three': 4}}}}
+    assert Cfg().model_dump() == {
+        "sub_model": {"vals": ["one", "two"], "sub_sub_model": {"dvals": {"three": 4}}}
+    }
 
-    env.set('cfg_sub_model__vals', 'invalid')
+    env.set("cfg_sub_model__vals", "invalid")
     with pytest.raises(
-        SettingsError, match='error parsing value for field "sub_model" from source "EnvSettingsSource"'
+        SettingsError,
+        match='error parsing value for field "sub_model" from source "EnvSettingsSource"',
     ):
         Cfg()
 
@@ -1629,9 +1718,9 @@ def test_nested_env_nonexisting_field(env):
     class Cfg(BaseSettings):
         sub_model: SubModel
 
-        model_config = SettingsConfigDict(env_prefix='cfg_', env_nested_delimiter='__')
+        model_config = SettingsConfigDict(env_prefix="cfg_", env_nested_delimiter="__")
 
-    env.set('cfg_sub_model__foo_vals', '[]')
+    env.set("cfg_sub_model__foo_vals", "[]")
     with pytest.raises(ValidationError):
         Cfg()
 
@@ -1643,9 +1732,9 @@ def test_nested_env_nonexisting_field_deep(env):
     class Cfg(BaseSettings):
         sub_model: SubModel
 
-        model_config = SettingsConfigDict(env_prefix='cfg_', env_nested_delimiter='__')
+        model_config = SettingsConfigDict(env_prefix="cfg_", env_nested_delimiter="__")
 
-    env.set('cfg_sub_model__vals__foo__bar__vals', '[]')
+    env.set("cfg_sub_model__vals__foo__bar__vals", "[]")
     with pytest.raises(ValidationError):
         Cfg()
 
@@ -1657,19 +1746,19 @@ def test_nested_env_union_complex_values(env):
     class Cfg(BaseSettings):
         sub_model: SubModel
 
-        model_config = SettingsConfigDict(env_prefix='cfg_', env_nested_delimiter='__')
+        model_config = SettingsConfigDict(env_prefix="cfg_", env_nested_delimiter="__")
 
-    env.set('cfg_sub_model__vals', '["one", "two"]')
-    assert Cfg().model_dump() == {'sub_model': {'vals': ['one', 'two']}}
+    env.set("cfg_sub_model__vals", '["one", "two"]')
+    assert Cfg().model_dump() == {"sub_model": {"vals": ["one", "two"]}}
 
-    env.set('cfg_sub_model__vals', '{"three": "four"}')
-    assert Cfg().model_dump() == {'sub_model': {'vals': {'three': 'four'}}}
+    env.set("cfg_sub_model__vals", '{"three": "four"}')
+    assert Cfg().model_dump() == {"sub_model": {"vals": {"three": "four"}}}
 
-    env.set('cfg_sub_model__vals', 'stringval')
+    env.set("cfg_sub_model__vals", "stringval")
     with pytest.raises(ValidationError):
         Cfg()
 
-    env.set('cfg_sub_model__vals', '{"invalid": dict}')
+    env.set("cfg_sub_model__vals", '{"invalid": dict}')
     with pytest.raises(ValidationError):
         Cfg()
 
@@ -1677,7 +1766,7 @@ def test_nested_env_union_complex_values(env):
 def test_nested_model_case_insensitive(env):
     class SubSubSub(BaseModel):
         VaL3: str
-        val4: str = Field(validation_alias='VAL4')
+        val4: str = Field(validation_alias="VAL4")
 
     class SubSub(BaseModel):
         Val2: str
@@ -1690,61 +1779,69 @@ def test_nested_model_case_insensitive(env):
     class Settings(BaseSettings):
         nested: Sub
 
-        model_config = SettingsConfigDict(env_nested_delimiter='__')
+        model_config = SettingsConfigDict(env_nested_delimiter="__")
 
-    env.set('nested', '{"val1": "v1", "sub_SUB": {"VAL2": "v2", "sub_SUB_sUb": {"vAl3": "v3", "VAL4": "v4"}}}')
+    env.set(
+        "nested",
+        '{"val1": "v1", "sub_SUB": {"VAL2": "v2", "sub_SUB_sUb": {"vAl3": "v3", "VAL4": "v4"}}}',
+    )
     s = Settings()
-    assert s.nested.VAL1 == 'v1'
-    assert s.nested.SUB_sub.Val2 == 'v2'
-    assert s.nested.SUB_sub.SUB_sub_SuB.VaL3 == 'v3'
-    assert s.nested.SUB_sub.SUB_sub_SuB.val4 == 'v4'
+    assert s.nested.VAL1 == "v1"
+    assert s.nested.SUB_sub.Val2 == "v2"
+    assert s.nested.SUB_sub.SUB_sub_SuB.VaL3 == "v3"
+    assert s.nested.SUB_sub.SUB_sub_SuB.val4 == "v4"
 
 
 def test_dotenv_extra_allow(tmp_path):
-    p = tmp_path / '.env'
-    p.write_text('a=b\nx=y')
+    p = tmp_path / ".env"
+    p.write_text("a=b\nx=y")
 
     class Settings(BaseSettings):
         a: str
 
-        model_config = SettingsConfigDict(env_file=p, extra='allow')
+        model_config = SettingsConfigDict(env_file=p, extra="allow")
 
     s = Settings()
-    assert s.a == 'b'
-    assert s.x == 'y'
+    assert s.a == "b"
+    assert s.x == "y"
 
 
 def test_dotenv_extra_forbid(tmp_path):
-    p = tmp_path / '.env'
-    p.write_text('a=b\nx=y')
+    p = tmp_path / ".env"
+    p.write_text("a=b\nx=y")
 
     class Settings(BaseSettings):
         a: str
 
-        model_config = SettingsConfigDict(env_file=p, extra='forbid')
+        model_config = SettingsConfigDict(env_file=p, extra="forbid")
 
     with pytest.raises(ValidationError) as exc_info:
         Settings()
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'extra_forbidden', 'loc': ('x',), 'msg': 'Extra inputs are not permitted', 'input': 'y'}
+        {
+            "type": "extra_forbidden",
+            "loc": ("x",),
+            "msg": "Extra inputs are not permitted",
+            "input": "y",
+        }
     ]
 
 
 def test_dotenv_extra_case_insensitive(tmp_path):
-    p = tmp_path / '.env'
-    p.write_text('a=b')
+    p = tmp_path / ".env"
+    p.write_text("a=b")
 
     class Settings(BaseSettings):
         A: str
 
-        model_config = SettingsConfigDict(env_file=p, extra='forbid')
+        model_config = SettingsConfigDict(env_file=p, extra="forbid")
 
     s = Settings()
-    assert s.A == 'b'
+    assert s.A == "b"
 
 
 def test_dotenv_extra_sub_model_case_insensitive(tmp_path):
-    p = tmp_path / '.env'
+    p = tmp_path / ".env"
     p.write_text('a=b\nSUB_model={"v": "v1"}')
 
     class SubModel(BaseModel):
@@ -1754,11 +1851,11 @@ def test_dotenv_extra_sub_model_case_insensitive(tmp_path):
         A: str
         sub_MODEL: SubModel
 
-        model_config = SettingsConfigDict(env_file=p, extra='forbid')
+        model_config = SettingsConfigDict(env_file=p, extra="forbid")
 
     s = Settings()
-    assert s.A == 'b'
-    assert s.sub_MODEL.v == 'v1'
+    assert s.A == "b"
+    assert s.sub_MODEL.v == "v1"
 
 
 def test_nested_bytes_field(env):
@@ -1770,29 +1867,33 @@ def test_nested_bytes_field(env):
         v0: str
         sub_model: SubModel
 
-        model_config = SettingsConfigDict(env_nested_delimiter='__', env_prefix='TEST_')
+        model_config = SettingsConfigDict(env_nested_delimiter="__", env_prefix="TEST_")
 
-    env.set('TEST_V0', 'v0')
-    env.set('TEST_SUB_MODEL__V1', 'v1')
-    env.set('TEST_SUB_MODEL__V2', 'v2')
+    env.set("TEST_V0", "v0")
+    env.set("TEST_SUB_MODEL__V1", "v1")
+    env.set("TEST_SUB_MODEL__V2", "v2")
 
     s = Settings()
 
-    assert s.v0 == 'v0'
-    assert s.sub_model.v1 == 'v1'
-    assert s.sub_model.v2 == b'v2'
+    assert s.v0 == "v0"
+    assert s.sub_model.v1 == "v1"
+    assert s.sub_model.v2 == b"v2"
 
 
 def test_protected_namespace_defaults():
     # pydantic default
-    with pytest.warns(UserWarning, match='Field "model_prefixed_field" has conflict with protected namespace "model_"'):
+    with pytest.warns(
+        UserWarning,
+        match='Field "model_prefixed_field" has conflict with protected namespace "model_"',
+    ):
 
         class Model(BaseSettings):
             model_prefixed_field: str
 
     # pydantic-settings default
     with pytest.raises(
-        UserWarning, match='Field "settings_prefixed_field" has conflict with protected namespace "settings_"'
+        UserWarning,
+        match='Field "settings_prefixed_field" has conflict with protected namespace "settings_"',
     ):
 
         class Model1(BaseSettings):
@@ -1816,11 +1917,11 @@ def test_case_sensitive_from_args(monkeypatch):
         foo: str
 
     # Need to patch os.environ to get build to work on Windows, where os.environ is case insensitive
-    monkeypatch.setattr(os, 'environ', value={'Foo': 'foo'})
+    monkeypatch.setattr(os, "environ", value={"Foo": "foo"})
     with pytest.raises(ValidationError) as exc_info:
         Settings(_case_sensitive=True)
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'missing', 'loc': ('foo',), 'msg': 'Field required', 'input': {}}
+        {"type": "missing", "loc": ("foo",), "msg": "Field required", "input": {}}
     ]
 
 
@@ -1828,30 +1929,30 @@ def test_env_prefix_from_args(env):
     class Settings(BaseSettings):
         apple: str
 
-    env.set('foobar_apple', 'has_prefix')
-    s = Settings(_env_prefix='foobar_')
-    assert s.apple == 'has_prefix'
+    env.set("foobar_apple", "has_prefix")
+    s = Settings(_env_prefix="foobar_")
+    assert s.apple == "has_prefix"
 
 
 def test_env_json_field(env):
     class Settings(BaseSettings):
         x: Json
 
-    env.set('x', '{"foo": "bar"}')
+    env.set("x", '{"foo": "bar"}')
 
     s = Settings()
-    assert s.x == {'foo': 'bar'}
+    assert s.x == {"foo": "bar"}
 
-    env.set('x', 'test')
+    env.set("x", "test")
     with pytest.raises(ValidationError) as exc_info:
         Settings()
     assert exc_info.value.errors(include_url=False) == [
         {
-            'type': 'json_invalid',
-            'loc': ('x',),
-            'msg': 'Invalid JSON: expected ident at line 1 column 2',
-            'input': 'test',
-            'ctx': {'error': 'expected ident at line 1 column 2'},
+            "type": "json_invalid",
+            "loc": ("x",),
+            "msg": "Invalid JSON: expected ident at line 1 column 2",
+            "input": "test",
+            "ctx": {"error": "expected ident at line 1 column 2"},
         }
     ]
 
@@ -1866,89 +1967,89 @@ def test_env_parse_enums(env):
         fruit: FruitsEnum
 
     with pytest.raises(ValidationError) as exc_info:
-        env.set('FRUIT', 'kiwi')
+        env.set("FRUIT", "kiwi")
         s = Settings()
     assert exc_info.value.errors(include_url=False) == [
         {
-            'type': 'enum',
-            'loc': ('fruit',),
-            'msg': 'Input should be 0, 1 or 2',
-            'input': 'kiwi',
-            'ctx': {'expected': '0, 1 or 2'},
+            "type": "enum",
+            "loc": ("fruit",),
+            "msg": "Input should be 0, 1 or 2",
+            "input": "kiwi",
+            "ctx": {"expected": "0, 1 or 2"},
         }
     ]
 
-    env.set('FRUIT', str(FruitsEnum.lime.value))
+    env.set("FRUIT", str(FruitsEnum.lime.value))
     s = Settings()
     assert s.fruit == FruitsEnum.lime
 
-    env.set('FRUIT', 'kiwi')
+    env.set("FRUIT", "kiwi")
     s = Settings(_env_parse_enums=True)
     assert s.fruit == FruitsEnum.kiwi
 
-    env.set('FRUIT', str(FruitsEnum.lime.value))
+    env.set("FRUIT", str(FruitsEnum.lime.value))
     s = Settings(_env_parse_enums=True)
     assert s.fruit == FruitsEnum.lime
 
 
 def test_env_parse_none_str(env):
-    env.set('x', 'null')
-    env.set('y', 'y_override')
+    env.set("x", "null")
+    env.set("y", "y_override")
 
     class Settings(BaseSettings):
-        x: Optional[str] = 'x_default'
-        y: Optional[str] = 'y_default'
+        x: Optional[str] = "x_default"
+        y: Optional[str] = "y_default"
 
     s = Settings()
-    assert s.x == 'null'
-    assert s.y == 'y_override'
-    s = Settings(_env_parse_none_str='null')
+    assert s.x == "null"
+    assert s.y == "y_override"
+    s = Settings(_env_parse_none_str="null")
     assert s.x is None
-    assert s.y == 'y_override'
+    assert s.y == "y_override"
 
-    env.set('nested__x', 'None')
-    env.set('nested__y', 'y_override')
-    env.set('nested__deep__z', 'None')
+    env.set("nested__x", "None")
+    env.set("nested__y", "y_override")
+    env.set("nested__deep__z", "None")
 
     class NestedBaseModel(BaseModel):
-        x: Optional[str] = 'x_default'
-        y: Optional[str] = 'y_default'
-        deep: Optional[dict] = {'z': 'z_default'}
-        keep: Optional[dict] = {'z': 'None'}
+        x: Optional[str] = "x_default"
+        y: Optional[str] = "y_default"
+        deep: Optional[dict] = {"z": "z_default"}
+        keep: Optional[dict] = {"z": "None"}
 
-    class NestedSettings(BaseSettings, env_nested_delimiter='__'):
+    class NestedSettings(BaseSettings, env_nested_delimiter="__"):
         nested: Optional[NestedBaseModel] = NestedBaseModel()
 
     s = NestedSettings()
-    assert s.nested.x == 'None'
-    assert s.nested.y == 'y_override'
-    assert s.nested.deep['z'] == 'None'
-    assert s.nested.keep['z'] == 'None'
-    s = NestedSettings(_env_parse_none_str='None')
+    assert s.nested.x == "None"
+    assert s.nested.y == "y_override"
+    assert s.nested.deep["z"] == "None"
+    assert s.nested.keep["z"] == "None"
+    s = NestedSettings(_env_parse_none_str="None")
     assert s.nested.x is None
-    assert s.nested.y == 'y_override'
-    assert s.nested.deep['z'] is None
-    assert s.nested.keep['z'] == 'None'
+    assert s.nested.y == "y_override"
+    assert s.nested.deep["z"] is None
+    assert s.nested.keep["z"] == "None"
 
 
 def test_env_json_field_dict(env):
     class Settings(BaseSettings):
         x: Json[Dict[str, int]]
 
-    env.set('x', '{"foo": 1}')
+    env.set("x", '{"foo": 1}')
 
     s = Settings()
-    assert s.x == {'foo': 1}
+    assert s.x == {"foo": 1}
 
-    env.set('x', '{"foo": "bar"}')
+    env.set("x", '{"foo": "bar"}')
     with pytest.raises(ValidationError) as exc_info:
         Settings()
     assert exc_info.value.errors(include_url=False) == [
         {
-            'type': 'int_parsing',
-            'loc': ('x', 'foo'),
-            'msg': 'Input should be a valid integer, unable to parse string as an integer',
-            'input': 'bar',
+            "type": "int_parsing",
+            "loc": ("x", "foo"),
+            "msg": "Input should be a valid integer, unable to parse string as an integer",
+            "input": "bar",
         }
     ]
 
@@ -1958,31 +2059,31 @@ def test_custom_env_source_default_values_from_config():
         pass
 
     class Settings(BaseSettings):
-        foo: str = 'test'
+        foo: str = "test"
 
-        model_config = SettingsConfigDict(env_prefix='prefix_', case_sensitive=True)
+        model_config = SettingsConfigDict(env_prefix="prefix_", case_sensitive=True)
 
     s = Settings()
-    assert s.model_config['env_prefix'] == 'prefix_'
-    assert s.model_config['case_sensitive'] is True
+    assert s.model_config["env_prefix"] == "prefix_"
+    assert s.model_config["case_sensitive"] is True
 
     c = CustomEnvSettingsSource(Settings)
-    assert c.env_prefix == 'prefix_'
+    assert c.env_prefix == "prefix_"
     assert c.case_sensitive is True
 
 
 def test_model_config_through_class_kwargs(env):
-    class Settings(BaseSettings, env_prefix='foobar_', title='Test Settings Model'):
+    class Settings(BaseSettings, env_prefix="foobar_", title="Test Settings Model"):
         apple: str
 
-    assert Settings.model_config['title'] == 'Test Settings Model'  # pydantic config
-    assert Settings.model_config['env_prefix'] == 'foobar_'  # pydantic-settings config
+    assert Settings.model_config["title"] == "Test Settings Model"  # pydantic config
+    assert Settings.model_config["env_prefix"] == "foobar_"  # pydantic-settings config
 
-    assert Settings.model_json_schema()['title'] == 'Test Settings Model'
+    assert Settings.model_json_schema()["title"] == "Test Settings Model"
 
-    env.set('foobar_apple', 'has_prefix')
+    env.set("foobar_apple", "has_prefix")
     s = Settings()
-    assert s.apple == 'has_prefix'
+    assert s.apple == "has_prefix"
 
 
 def test_root_model_as_field(env):
@@ -1995,23 +2096,25 @@ def test_root_model_as_field(env):
     class Settings(BaseSettings):
         z: FooRoot
 
-    env.set('z', '[{"x": 1, "y": {"foo": 1}}, {"x": 2, "y": {"foo": 2}}]')
+    env.set("z", '[{"x": 1, "y": {"foo": 1}}, {"x": 2, "y": {"foo": 2}}]')
     s = Settings()
-    assert s.model_dump() == {'z': [{'x': 1, 'y': {'foo': 1}}, {'x': 2, 'y': {'foo': 2}}]}
+    assert s.model_dump() == {
+        "z": [{"x": 1, "y": {"foo": 1}}, {"x": 2, "y": {"foo": 2}}]
+    }
 
 
 def test_optional_field_from_env(env):
     class Settings(BaseSettings):
         x: Optional[str] = None
 
-    env.set('x', '123')
+    env.set("x", "123")
 
     s = Settings()
-    assert s.x == '123'
+    assert s.x == "123"
 
 
 def test_dotenv_optional_json_field(tmp_path):
-    p = tmp_path / '.env'
+    p = tmp_path / ".env"
     p.write_text("""DATA='{"foo":"bar"}'""")
 
     class Settings(BaseSettings):
@@ -2020,11 +2123,11 @@ def test_dotenv_optional_json_field(tmp_path):
         data: Optional[Json[Dict[str, str]]] = Field(default=None)
 
     s = Settings()
-    assert s.data == {'foo': 'bar'}
+    assert s.data == {"foo": "bar"}
 
 
 def test_json_file(tmp_path):
-    p = tmp_path / '.env'
+    p = tmp_path / ".env"
     p.write_text(
         """
     {"foobar": "Hello", "nested": {"nested_field": "world!"}, "null_field": null}
@@ -2052,8 +2155,8 @@ def test_json_file(tmp_path):
             return (JsonConfigSettingsSource(settings_cls),)
 
     s = Settings()
-    assert s.foobar == 'Hello'
-    assert s.nested.nested_field == 'world!'
+    assert s.foobar == "Hello"
+    assert s.nested.nested_field == "world!"
 
 
 def test_json_no_file():
@@ -2075,9 +2178,9 @@ def test_json_no_file():
     assert s.model_dump() == {}
 
 
-@pytest.mark.skipif(yaml is None, reason='pyYaml is not installed')
+@pytest.mark.skipif(yaml is None, reason="pyYaml is not installed")
 def test_yaml_file(tmp_path):
-    p = tmp_path / '.env'
+    p = tmp_path / ".env"
     p.write_text(
         """
     foobar: "Hello"
@@ -2108,11 +2211,11 @@ def test_yaml_file(tmp_path):
             return (YamlConfigSettingsSource(settings_cls),)
 
     s = Settings()
-    assert s.foobar == 'Hello'
-    assert s.nested.nested_field == 'world!'
+    assert s.foobar == "Hello"
+    assert s.nested.nested_field == "world!"
 
 
-@pytest.mark.skipif(yaml is None, reason='pyYaml is not installed')
+@pytest.mark.skipif(yaml is None, reason="pyYaml is not installed")
 def test_yaml_no_file():
     class Settings(BaseSettings):
         model_config = SettingsConfigDict(yaml_file=None)
@@ -2132,9 +2235,12 @@ def test_yaml_no_file():
     assert s.model_dump() == {}
 
 
-@pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
+@pytest.mark.skipif(
+    sys.version_info <= (3, 11) and tomli is None,
+    reason="tomli/tomllib is not installed",
+)
 def test_toml_file(tmp_path):
-    p = tmp_path / '.env'
+    p = tmp_path / ".env"
     p.write_text(
         """
     foobar = "Hello"
@@ -2164,11 +2270,14 @@ def test_toml_file(tmp_path):
             return (TomlConfigSettingsSource(settings_cls),)
 
     s = Settings()
-    assert s.foobar == 'Hello'
-    assert s.nested.nested_field == 'world!'
+    assert s.foobar == "Hello"
+    assert s.nested.nested_field == "world!"
 
 
-@pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
+@pytest.mark.skipif(
+    sys.version_info <= (3, 11) and tomli is None,
+    reason="tomli/tomllib is not installed",
+)
 def test_toml_no_file():
     class Settings(BaseSettings):
         model_config = SettingsConfigDict(toml_file=None)
@@ -2188,9 +2297,12 @@ def test_toml_no_file():
     assert s.model_dump() == {}
 
 
-@pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
+@pytest.mark.skipif(
+    sys.version_info <= (3, 11) and tomli is None,
+    reason="tomli/tomllib is not installed",
+)
 def test_pyproject_toml_file(cd_tmp_path: Path):
-    pyproject = cd_tmp_path / 'pyproject.toml'
+    pyproject = cd_tmp_path / "pyproject.toml"
     pyproject.write_text(
         """
     [tool.pydantic-settings]
@@ -2216,13 +2328,16 @@ def test_pyproject_toml_file(cd_tmp_path: Path):
             return (PyprojectTomlConfigSettingsSource(settings_cls),)
 
     s = Settings()
-    assert s.foobar == 'Hello'
-    assert s.nested.nested_field == 'world!'
+    assert s.foobar == "Hello"
+    assert s.nested.nested_field == "world!"
 
 
-@pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
+@pytest.mark.skipif(
+    sys.version_info <= (3, 11) and tomli is None,
+    reason="tomli/tomllib is not installed",
+)
 def test_pyproject_toml_file_explicit(cd_tmp_path: Path):
-    pyproject = cd_tmp_path / 'child' / 'grandchild' / 'pyproject.toml'
+    pyproject = cd_tmp_path / "child" / "grandchild" / "pyproject.toml"
     pyproject.parent.mkdir(parents=True)
     pyproject.write_text(
         """
@@ -2233,7 +2348,7 @@ def test_pyproject_toml_file_explicit(cd_tmp_path: Path):
     nested_field = "world!"
     """
     )
-    (cd_tmp_path / 'pyproject.toml').write_text(
+    (cd_tmp_path / "pyproject.toml").write_text(
         """
     [tool.pydantic-settings]
     foobar = "fail"
@@ -2258,16 +2373,19 @@ def test_pyproject_toml_file_explicit(cd_tmp_path: Path):
             return (PyprojectTomlConfigSettingsSource(settings_cls, pyproject),)
 
     s = Settings()
-    assert s.foobar == 'Hello'
-    assert s.nested.nested_field == 'world!'
+    assert s.foobar == "Hello"
+    assert s.nested.nested_field == "world!"
 
 
-@pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
+@pytest.mark.skipif(
+    sys.version_info <= (3, 11) and tomli is None,
+    reason="tomli/tomllib is not installed",
+)
 def test_pyproject_toml_file_parent(mocker: MockerFixture, tmp_path: Path):
-    cwd = tmp_path / 'child' / 'grandchild' / 'cwd'
+    cwd = tmp_path / "child" / "grandchild" / "cwd"
     cwd.mkdir(parents=True)
-    mocker.patch('pydantic_settings.sources.Path.cwd', return_value=cwd)
-    (cwd.parent.parent / 'pyproject.toml').write_text(
+    mocker.patch("pydantic_settings.sources.Path.cwd", return_value=cwd)
+    (cwd.parent.parent / "pyproject.toml").write_text(
         """
     [tool.pydantic-settings]
     foobar = "Hello"
@@ -2276,7 +2394,7 @@ def test_pyproject_toml_file_parent(mocker: MockerFixture, tmp_path: Path):
     nested_field = "world!"
     """
     )
-    (tmp_path / 'pyproject.toml').write_text(
+    (tmp_path / "pyproject.toml").write_text(
         """
     [tool.pydantic-settings]
     foobar = "fail"
@@ -2301,13 +2419,16 @@ def test_pyproject_toml_file_parent(mocker: MockerFixture, tmp_path: Path):
             return (PyprojectTomlConfigSettingsSource(settings_cls),)
 
     s = Settings()
-    assert s.foobar == 'Hello'
-    assert s.nested.nested_field == 'world!'
+    assert s.foobar == "Hello"
+    assert s.nested.nested_field == "world!"
 
 
-@pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
+@pytest.mark.skipif(
+    sys.version_info <= (3, 11) and tomli is None,
+    reason="tomli/tomllib is not installed",
+)
 def test_pyproject_toml_file_header(cd_tmp_path: Path):
-    pyproject = cd_tmp_path / 'subdir' / 'pyproject.toml'
+    pyproject = cd_tmp_path / "subdir" / "pyproject.toml"
     pyproject.parent.mkdir()
     pyproject.write_text(
         """
@@ -2324,7 +2445,9 @@ def test_pyproject_toml_file_header(cd_tmp_path: Path):
 
     class Settings(BaseSettings):
         status: str
-        model_config = SettingsConfigDict(extra='forbid', pyproject_toml_table_header=('tool', 'my.tool', 'foo'))
+        model_config = SettingsConfigDict(
+            extra="forbid", pyproject_toml_table_header=("tool", "my.tool", "foo")
+        )
 
         @classmethod
         def settings_customise_sources(
@@ -2333,11 +2456,14 @@ def test_pyproject_toml_file_header(cd_tmp_path: Path):
             return (PyprojectTomlConfigSettingsSource(settings_cls, pyproject),)
 
     s = Settings()
-    assert s.status == 'success'
+    assert s.status == "success"
 
 
-@pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
-@pytest.mark.parametrize('depth', [0, 99])
+@pytest.mark.skipif(
+    sys.version_info <= (3, 11) and tomli is None,
+    reason="tomli/tomllib is not installed",
+)
+@pytest.mark.parametrize("depth", [0, 99])
 def test_pyproject_toml_no_file(cd_tmp_path: Path, depth: int):
     class Settings(BaseSettings):
         model_config = SettingsConfigDict(pyproject_toml_depth=depth)
@@ -2352,10 +2478,13 @@ def test_pyproject_toml_no_file(cd_tmp_path: Path, depth: int):
     assert s.model_dump() == {}
 
 
-@pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
+@pytest.mark.skipif(
+    sys.version_info <= (3, 11) and tomli is None,
+    reason="tomli/tomllib is not installed",
+)
 def test_pyproject_toml_no_file_explicit(tmp_path: Path):
-    pyproject = tmp_path / 'child' / 'pyproject.toml'
-    (tmp_path / 'pyproject.toml').write_text('[tool.pydantic-settings]\nfield = "fail"')
+    pyproject = tmp_path / "child" / "pyproject.toml"
+    (tmp_path / "pyproject.toml").write_text('[tool.pydantic-settings]\nfield = "fail"')
 
     class Settings(BaseSettings):
         model_config = SettingsConfigDict()
@@ -2369,16 +2498,21 @@ def test_pyproject_toml_no_file_explicit(tmp_path: Path):
             return (PyprojectTomlConfigSettingsSource(settings_cls, pyproject),)
 
     s = Settings()
-    assert s.model_dump() == {'field': None}
+    assert s.model_dump() == {"field": None}
 
 
-@pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
-@pytest.mark.parametrize('depth', [0, 1, 2])
-def test_pyproject_toml_no_file_too_shallow(depth: int, mocker: MockerFixture, tmp_path: Path):
-    cwd = tmp_path / 'child' / 'grandchild' / 'cwd'
+@pytest.mark.skipif(
+    sys.version_info <= (3, 11) and tomli is None,
+    reason="tomli/tomllib is not installed",
+)
+@pytest.mark.parametrize("depth", [0, 1, 2])
+def test_pyproject_toml_no_file_too_shallow(
+    depth: int, mocker: MockerFixture, tmp_path: Path
+):
+    cwd = tmp_path / "child" / "grandchild" / "cwd"
     cwd.mkdir(parents=True)
-    mocker.patch('pydantic_settings.sources.Path.cwd', return_value=cwd)
-    (tmp_path / 'pyproject.toml').write_text(
+    mocker.patch("pydantic_settings.sources.Path.cwd", return_value=cwd)
+    (tmp_path / "pyproject.toml").write_text(
         """
     [tool.pydantic-settings]
     foobar = "fail"
@@ -2407,10 +2541,13 @@ def test_pyproject_toml_no_file_too_shallow(depth: int, mocker: MockerFixture, t
     assert not s.nested.nested_field
 
 
-@pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
+@pytest.mark.skipif(
+    sys.version_info <= (3, 11) and tomli is None,
+    reason="tomli/tomllib is not installed",
+)
 def test_multiple_file_toml(tmp_path):
-    p1 = tmp_path / '.env.toml1'
-    p2 = tmp_path / '.env.toml2'
+    p1 = tmp_path / ".env.toml1"
+    p2 = tmp_path / ".env.toml2"
     p1.write_text(
         """
     toml1=1
@@ -2438,13 +2575,13 @@ def test_multiple_file_toml(tmp_path):
             return (TomlConfigSettingsSource(settings_cls, toml_file=[p1, p2]),)
 
     s = Settings()
-    assert s.model_dump() == {'toml1': 1, 'toml2': 2}
+    assert s.model_dump() == {"toml1": 1, "toml2": 2}
 
 
-@pytest.mark.skipif(yaml is None, reason='pyYAML is not installed')
+@pytest.mark.skipif(yaml is None, reason="pyYAML is not installed")
 def test_multiple_file_yaml(tmp_path):
-    p3 = tmp_path / '.env.yaml3'
-    p4 = tmp_path / '.env.yaml4'
+    p3 = tmp_path / ".env.yaml3"
+    p4 = tmp_path / ".env.yaml4"
     p3.write_text(
         """
     yaml3: 3
@@ -2472,17 +2609,17 @@ def test_multiple_file_yaml(tmp_path):
             return (YamlConfigSettingsSource(settings_cls, yaml_file=[p3, p4]),)
 
     s = Settings()
-    assert s.model_dump() == {'yaml3': 3, 'yaml4': 4}
+    assert s.model_dump() == {"yaml3": 3, "yaml4": 4}
 
 
 def test_multiple_file_json(tmp_path):
-    p5 = tmp_path / '.env.json5'
-    p6 = tmp_path / '.env.json6'
+    p5 = tmp_path / ".env.json5"
+    p6 = tmp_path / ".env.json6"
 
-    with open(p5, 'w') as f5:
-        json.dump({'json5': 5}, f5)
-    with open(p6, 'w') as f6:
-        json.dump({'json6': 6}, f6)
+    with open(p5, "w") as f5:
+        json.dump({"json5": 5}, f5)
+    with open(p6, "w") as f6:
+        json.dump({"json6": 6}, f6)
 
     class Settings(BaseSettings):
         json5: int
@@ -2500,76 +2637,89 @@ def test_multiple_file_json(tmp_path):
             return (JsonConfigSettingsSource(settings_cls, json_file=[p5, p6]),)
 
     s = Settings()
-    assert s.model_dump() == {'json5': 5, 'json6': 6}
+    assert s.model_dump() == {"json5": 5, "json6": 6}
 
 
 def test_dotenv_with_alias_and_env_prefix(tmp_path):
-    p = tmp_path / '.env'
-    p.write_text('xxx__foo=1\nxxx__bar=2')
+    p = tmp_path / ".env"
+    p.write_text("xxx__foo=1\nxxx__bar=2")
 
     class Settings(BaseSettings):
-        model_config = SettingsConfigDict(env_file=p, env_prefix='xxx__')
+        model_config = SettingsConfigDict(env_file=p, env_prefix="xxx__")
 
-        foo: str = ''
-        bar_alias: str = Field('', validation_alias='xxx__bar')
+        foo: str = ""
+        bar_alias: str = Field("", validation_alias="xxx__bar")
 
     s = Settings()
-    assert s.model_dump() == {'foo': '1', 'bar_alias': '2'}
+    assert s.model_dump() == {"foo": "1", "bar_alias": "2"}
 
     class Settings1(BaseSettings):
-        model_config = SettingsConfigDict(env_file=p, env_prefix='xxx__')
+        model_config = SettingsConfigDict(env_file=p, env_prefix="xxx__")
 
-        foo: str = ''
-        bar_alias: str = Field('', alias='bar')
+        foo: str = ""
+        bar_alias: str = Field("", alias="bar")
 
     with pytest.raises(ValidationError) as exc_info:
         Settings1()
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'extra_forbidden', 'loc': ('xxx__bar',), 'msg': 'Extra inputs are not permitted', 'input': '2'}
+        {
+            "type": "extra_forbidden",
+            "loc": ("xxx__bar",),
+            "msg": "Extra inputs are not permitted",
+            "input": "2",
+        }
     ]
 
 
 def test_dotenv_with_alias_and_env_prefix_nested(tmp_path):
-    p = tmp_path / '.env'
-    p.write_text('xxx__bar=0\nxxx__nested__a=1\nxxx__nested__b=2')
+    p = tmp_path / ".env"
+    p.write_text("xxx__bar=0\nxxx__nested__a=1\nxxx__nested__b=2")
 
     class NestedSettings(BaseModel):
-        a: str = 'a'
-        b: str = 'b'
+        a: str = "a"
+        b: str = "b"
 
     class Settings(BaseSettings):
-        model_config = SettingsConfigDict(env_prefix='xxx__', env_nested_delimiter='__', env_file=p)
+        model_config = SettingsConfigDict(
+            env_prefix="xxx__", env_nested_delimiter="__", env_file=p
+        )
 
-        foo: str = ''
-        bar_alias: str = Field('', alias='xxx__bar')
-        nested_alias: NestedSettings = Field(default_factory=NestedSettings, alias='xxx__nested')
+        foo: str = ""
+        bar_alias: str = Field("", alias="xxx__bar")
+        nested_alias: NestedSettings = Field(
+            default_factory=NestedSettings, alias="xxx__nested"
+        )
 
     s = Settings()
-    assert s.model_dump() == {'foo': '', 'bar_alias': '0', 'nested_alias': {'a': '1', 'b': '2'}}
+    assert s.model_dump() == {
+        "foo": "",
+        "bar_alias": "0",
+        "nested_alias": {"a": "1", "b": "2"},
+    }
 
 
 def test_dotenv_with_extra_and_env_prefix(tmp_path):
-    p = tmp_path / '.env'
-    p.write_text('xxx__foo=1\nxxx__extra_var=extra_value')
+    p = tmp_path / ".env"
+    p.write_text("xxx__foo=1\nxxx__extra_var=extra_value")
 
     class Settings(BaseSettings):
-        model_config = SettingsConfigDict(extra='allow', env_file=p, env_prefix='xxx__')
+        model_config = SettingsConfigDict(extra="allow", env_file=p, env_prefix="xxx__")
 
-        foo: str = ''
+        foo: str = ""
 
     s = Settings()
-    assert s.model_dump() == {'foo': '1', 'extra_var': 'extra_value'}
+    assert s.model_dump() == {"foo": "1", "extra_var": "extra_value"}
 
 
 def test_nested_field_with_alias_init_source():
     class NestedSettings(BaseModel):
-        foo: str = Field(alias='fooAlias')
+        foo: str = Field(alias="fooAlias")
 
     class Settings(BaseSettings):
         nested_foo: NestedSettings
 
-    s = Settings(nested_foo=NestedSettings(fooAlias='EXAMPLE'))
-    assert s.model_dump() == {'nested_foo': {'foo': 'EXAMPLE'}}
+    s = Settings(nested_foo=NestedSettings(fooAlias="EXAMPLE"))
+    assert s.model_dump() == {"nested_foo": {"foo": "EXAMPLE"}}
 
 
 def test_nested_models_as_dict_value(env):
@@ -2580,9 +2730,30 @@ def test_nested_models_as_dict_value(env):
         nested: NestedSettings
         sub_dict: Dict[str, NestedSettings]
 
-        model_config = SettingsConfigDict(env_nested_delimiter='__')
+        model_config = SettingsConfigDict(env_nested_delimiter="__")
 
-    env.set('nested__foo', '{"a": 1}')
-    env.set('sub_dict__bar__foo', '{"b": 2}')
+    env.set("nested__foo", '{"a": 1}')
+    env.set("sub_dict__bar__foo", '{"b": 2}')
     s = Settings()
-    assert s.model_dump() == {'nested': {'foo': {'a': 1}}, 'sub_dict': {'bar': {'foo': {'b': 2}}}}
+    assert s.model_dump() == {
+        "nested": {"foo": {"a": 1}},
+        "sub_dict": {"bar": {"foo": {"b": 2}}},
+    }
+
+
+def test_nested_models_leaf_vs_deeper_env_dict_assumed(env):
+    class NestedSettings(BaseModel):
+        foo: str
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_nested_delimiter="__")
+
+        nested: NestedSettings
+
+    env.set("nested__foo", "string")
+    env.set(
+        "nested__foo__bar",
+        "this should not be evaluated, since foo is a string by annotation and not a dict",
+    )
+    s = Settings()
+    assert s.model_dump() == {"nested": {"foo": "string"}}


### PR DESCRIPTION
If a model defines a leaf as e.g. a string and the user or system sets an
environment var with an additional `env_nested_delimiter + suffix`,
 `explode_env_vars` was treating the string as a `dict` by
  adding an item to it.

This fix checks if the target is indeed a `dict`.

In that regard, the whole `explode_env_vars` seems a bit wasteful, in
terms of possible throwing away already computed values, if a deeper
environment variable is processed earlier (which is possible, since the
iteration order of `os.environ` seems unpredictable).
