### PR TITLE
fix/deeply nested env conflicts with non dict model item

### DIFF
--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -620,7 +620,8 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
             target_field: FieldInfo | None = field
             for key in keys:
                 target_field = self.next_field(target_field, key)
-                env_var = env_var.setdefault(key, {})
+                if isinstance(env_var, dict):
+                    env_var = env_var.setdefault(key, {})
 
             # get proper field with last_key
             target_field = self.next_field(target_field, last_key)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2602,5 +2602,9 @@ def test_nested_models_leaf_vs_deeper_env_dict_assumed(env):
         'nested__foo__bar',
         'this should not be evaluated, since foo is a string by annotation and not a dict',
     )
+    env.set(
+        'nested__foo__bar__baz',
+        'one more',
+    )
     s = Settings()
     assert s.model_dump() == {'nested': {'foo': 'string'}}


### PR DESCRIPTION
fix: a second level of environment nesting expected a dict

When there was a second/deeper level of environment variable nesting
another part of the code raised an exception.